### PR TITLE
Utility middlewares

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,10 @@ gemspec
 
 gem 'goliath', :path => '../goliath'
 
+group :development do
+  gem 'rake'
+end
+
 # Gems for testing and coverage
 group :test do
   gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,14 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in goliath-contrib.gemspec
 gemspec
+
+gem 'goliath', :path => '../goliath'
+
+# Gems for testing and coverage
+group :test do
+  gem 'pry'
+  gem 'rspec'
+  gem 'guard'
+  gem 'guard-rspec'
+  gem 'guard-yard'
+end

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,20 @@
+# -*- ruby -*-
+
+format = 'progress' # 'doc' for more verbose, 'progress' for less
+tags   = %w[ ]
+guard 'rspec', :version => 2, :cli => "--format #{format} #{ tags.map{|tag| "--tag #{tag}"}.join(' ')  }" do
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^lib/(.+)\.rb$})           { |m| "spec/#{m[1]}_spec.rb"  }
+  watch(%r{^examples/(.+)\.rb$})      { |m| "spec/integration/#{m[1]}_spec.rb" }
+
+  watch('spec/spec_helper.rb')         { 'spec' }
+  watch(/spec\/support\/(.+)\.rb/)     { 'spec' }
+end
+
+group :docs do
+  guard 'yard' do
+    watch(%r{app/.+\.rb})
+    watch(%r{lib/.+\.rb})
+    watch(%r{ext/.+\.c})
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,27 @@
-#!/usr/bin/env rake
-require "bundler/gem_tasks"
+require 'bundler'
+Bundler::GemHelper.install_tasks
+
+require 'yard'
+require 'rspec/core/rake_task'
+require 'rake/testtask'
+
+task :default => [:test]
+task :test => [:spec, :unit]
+
+desc "run the unit test"
+Rake::TestTask.new(:unit) do |t|
+   t.libs << "test"
+   t.test_files = FileList['test/**/*_test.rb']
+   t.verbose = true
+end
+
+desc "run spec tests"
+RSpec::Core::RakeTask.new('spec') do |t|
+  t.pattern = 'spec/**/*_spec.rb'
+end
+
+desc 'Generate documentation'
+YARD::Rake::YardocTask.new do |t|
+  t.files   = ['lib/**/*.rb', '-', 'LICENSE']
+  t.options = ['--main', 'README.md', '--no-private']
+end

--- a/examples/test_rig.rb
+++ b/examples/test_rig.rb
@@ -12,7 +12,16 @@ require 'goliath/contrib/rack/force_timeout'
 require 'goliath/contrib/rack/handle_exceptions'
 
 #
-# A test endpoint allowing fault injection, variable delay, or a response forced by the client.
+# A test endpoint allowing fault injection, variable delay, or a response forced
+# by the client.  Besides being a nice demo of those middlewares, it's a useful
+# test dummy for seeing how your SOA apps handle downstream failures.
+#
+# Launch with
+#
+#     bundle exec ./examples/test_rig.rb       -s -p 9000 -e development &
+#
+# If using it as a test rig, launch with `-e production`. The test rig acts on
+# the following URL parameters:
 #
 # * `_force_timeout`                    -- raise an error if response takes longer than given time
 # * `_force_delay`                      -- delay the given length of time before responding
@@ -20,27 +29,27 @@ require 'goliath/contrib/rack/handle_exceptions'
 # * `_force_fail`/`_force_fail_after`   -- raise an error of the given type (eg `_force_fail_pre=400` causes a BadRequestError)
 # * `_force_status`, `_force_headers`, or `_force_body' --  replace the given component directly.
 #
-# @example delay for 2 seconds
+# @example delay for 2 seconds:
 #   curl -v 'http://127.0.0.1:9000/?_force_delay=2'
-#   => {"_delay_ms":2.0,"_randelay_ms":0.0,"_actual_ms":2.006265640258789}
+#   => Headers: X-Resp-Delay: 2.0 / X-Resp-Randelay: 0.0 / X-Resp-Actual: 2.003681182861328
 #
-# @example drop connection
+# @example drop connection:
 #   curl -v 'http://127.0.0.1:9000/?_force_drop=true'
 #
-# @example delay for 2 seconds, then drop the connection
+# @example delay for 2 seconds, then drop the connection:
 #   curl -v 'http://127.0.0.1:9000/?_force_delay=2&_force_drop_after=true'
 #
-# @example force timeout: first call is 200 OK, second will error with 408 RequestTimeoutError
+# @example force timeout; first call is 200 OK, second will error with 408 RequestTimeoutError:
 #   curl -v 'http://127.0.0.1:9000/?_force_timeout=1.0&_force_delay=0.5'
-#   => {"_delay_ms":0.5,"_randelay_ms":0.0,"_actual_ms":0.53464674949646}
+#   => Headers: X-Resp-Delay: 0.5 / X-Resp-Randelay: 0.0 / X-Resp-Actual: 0.513401985168457 / X-Resp-Timeout: 1.0
 #   curl -v 'http://127.0.0.1:9000/?_force_timeout=1.0&_force_delay=2.0'
 #   => {"status":408,"error":"RequestTimeoutError","message":"Request exceeded 1.0 seconds"}
 #
-# @example simulate a 503
+# @example simulate a 503:
 #   curl -v 'http://127.0.0.1:9000/?_force_fault=503'
 #   => {"status":503,"error":"ServiceUnavailableError","message":"Injected middleware fault 503"}
 #
-# @example force-set headers and body
+# @example force-set headers and body:
 #   curl -v -H "Content-Type: application/json" --data-ascii '{"_force_headers":{"X-Question":"What is brown and sticky"},"_force_body":{"answer":"a stick"}}' 'http://127.0.0.1:9001/'
 #   => {"answer":"a stick"}
 #

--- a/examples/test_rig.rb
+++ b/examples/test_rig.rb
@@ -48,11 +48,12 @@ class TestRig < Goliath::API
   include Goliath::Contrib::CaptureHeaders
 
   def self.set_middleware!
+    use Goliath::Rack::Heartbeat                 # respond to /status with 200, OK (monitoring, etc)
     use Goliath::Rack::Tracer                    # log trace statistics
-    use Goliath::Rack::Params                    # parse & merge query and body parameters
     use Goliath::Rack::DefaultMimeType           # cleanup accepted media types
     use Goliath::Rack::Render, 'json'            # auto-negotiate response format
     use Goliath::Contrib::Rack::HandleExceptions # turn raised errors into HTTP responses
+    use Goliath::Rack::Params                    # parse & merge query and body parameters
 
     # turn params like '_force_delay' into env vars :force_delay
     use(Goliath::Contrib::Rack::ConfigurateFromParams,

--- a/examples/test_rig.rb
+++ b/examples/test_rig.rb
@@ -1,0 +1,53 @@
+#!/usr/bin/env ruby
+# $:.unshift File.expand_path('../lib', File.dirname(__FILE__))
+
+require 'goliath'
+require 'goliath/contrib/rack/diagnostics'
+require 'goliath/contrib/rack/force_delay'
+require 'goliath/contrib/rack/force_drop'
+require 'goliath/contrib/rack/force_fault'
+require 'goliath/contrib/rack/force_response'
+require 'goliath/contrib/rack/handle_exceptions'
+
+#
+# A test endpoint allowing fault injection, variable delay, or a response forced by the client.
+#
+# * with `_delay`               parameter, delay the given length of time before responding
+# * with `_drop`/`_drop_post`   parameter, drop connection with no response
+# * with `_fail`/`_fail_post`   parameter, raise an error of the given type (eg `_fail_pre=400` causes a BadRequestError)
+# * with `_status`, `_headers`, or `_body' parameter, replace the given component directly.
+#
+# @example set headers
+#   curl -v -H "Content-Type: application/json" --data-ascii '{"_headers":{"X-Question":"What is brown and sticky"},"_body":{"answer":"a stick"}}' 'http://127.0.0.1:9001/'
+#
+# @example drop connection
+#   curl -v 'http://127.0.0.1:9000/?_drop_pre=true'
+#
+# @example delay for 3 seconds
+#   curl -v 'http://127.0.0.1:9000/?_delay=2'
+#
+# @example delay for 3 seconds, then drop the connection (using drop_after)
+#   curl -v 'http://127.0.0.1:9000/?_delay=2&_drop_post=true'
+#
+class TestRig < Goliath::API
+  include Goliath::Contrib::CaptureHeaders
+
+  def self.set_middleware!
+    use Goliath::Rack::Tracer                    # log trace statistics
+    use Goliath::Rack::Params                    # parse & merge query and body parameters
+    use Goliath::Rack::DefaultMimeType           # cleanup accepted media types
+    use Goliath::Rack::Render, 'json'            # auto-negotiate response format
+
+    use Goliath::Contrib::Rack::HandleExceptions # turn raised errors into HTTP responses
+    use Goliath::Contrib::Rack::ForceDrop        # drop connection if 'drop' param
+    use Goliath::Contrib::Rack::ForceFault       # raise an error if 'fail' param
+    use Goliath::Contrib::Rack::ForceResponse    # replace with given value if '_status', '_headers' or '_body' is returned
+    use Goliath::Contrib::Rack::ForceDelay       # force response to take at least (_delay +/- _randelay) seconds
+    use Goliath::Contrib::Rack::Diagnostics      # summarize the request in the response headers
+  end
+  self.set_middleware!
+
+  def response(env)
+    [200, { 'X-API' => self.class.name }, {}]
+  end
+end

--- a/goliath-contrib.gemspec
+++ b/goliath-contrib.gemspec
@@ -1,23 +1,61 @@
 # -*- encoding: utf-8 -*-
+$:.push File.expand_path("../lib", __FILE__)
+require 'goliath/contrib/version'
 
-require File.expand_path('../lib/goliath/contrib', __FILE__)
+Gem::Specification.new do |s|
+  s.name        = "goliath-contrib"
+  s.version     = Goliath::Contrib::VERSION
 
-# require './lib/goliath/contrib'
+  s.authors     = ["goliath-io"]
+  s.email       = ["goliath-io@googlegroups.com"]
 
-Gem::Specification.new do |gem|
-  gem.authors       = ["goliath-io"]
-  gem.email         = ["goliath-io@googlegroups.com"]
+  s.homepage    = "https://github.com/postrank-labs/goliath-contrib"
+  s.summary     = "Contributed Goliath middleware, plugins, and utilities"
+  s.description = s.summary
 
-  gem.homepage      = "https://github.com/postrank-labs/goliath-contrib"
-  gem.description   = "Contributed Goliath middleware, plugins, and utilities"
-  gem.summary       = gem.description
+  s.required_ruby_version = '>=1.9.2'
 
-  gem.files         = `git ls-files`.split($\)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.name          = "goliath-contrib"
-  gem.require_paths = ["lib"]
-  gem.version       = Goliath::Contrib::VERSION
+  s.add_dependency 'goliath'
 
-  gem.add_dependency 'goliath'  
+  s.add_development_dependency 'rspec', '>2.0'
+  s.add_development_dependency 'nokogiri'
+  s.add_development_dependency 'em-http-request', '>=1.0.0'
+  s.add_development_dependency 'em-mongo', '~> 0.4.0'
+  s.add_development_dependency 'rack-rewrite'
+  s.add_development_dependency 'multipart_body'
+  s.add_development_dependency 'amqp', '>=0.7.1'
+  s.add_development_dependency 'em-websocket-client'
+
+  s.add_development_dependency 'tilt', '>=1.2.2'
+  s.add_development_dependency 'haml', '>=3.0.25'
+  s.add_development_dependency 'yard'
+
+  s.add_development_dependency 'guard'
+  s.add_development_dependency 'guard-rspec'
+
+  if RUBY_PLATFORM != 'java'
+    s.add_development_dependency 'yajl-ruby'
+    s.add_development_dependency 'bluecloth'
+    s.add_development_dependency 'bson_ext'
+  else
+    s.add_development_dependency 'json-jruby'
+    s.add_development_dependency 'maruku'
+  end
+
+  if RUBY_PLATFORM.include?('darwin')
+    s.add_development_dependency 'growl', '~> 1.0.3'
+    s.add_development_dependency 'rb-fsevent'
+  end
+
+  ignores = File.readlines(".gitignore").grep(/\S+/).map {|i| i.chomp }
+  dotfiles = [".gemtest", ".gitignore", ".rspec", ".yardopts"]
+
+  # s.files         = `git ls-files`.split($\)
+  # s.executables   = s.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  # s.test_files    = s.files.grep(%r{^(test|spec|features)/})
+  # s.require_paths = ["lib"]
+
+  s.files = Dir["**/*"].reject {|f| File.directory?(f) || ignores.any? {|i| File.fnmatch(i, f) } } + dotfiles
+  s.test_files = s.files.grep(/^spec\//)
+  s.require_paths = ['lib']
 end

--- a/goliath-contrib.gemspec
+++ b/goliath-contrib.gemspec
@@ -18,20 +18,16 @@ Gem::Specification.new do |s|
   s.add_dependency 'goliath'
 
   s.add_development_dependency 'rspec', '>2.0'
-  s.add_development_dependency 'nokogiri'
-  s.add_development_dependency 'em-http-request', '>=1.0.0'
-  s.add_development_dependency 'em-mongo', '~> 0.4.0'
-  s.add_development_dependency 'rack-rewrite'
-  s.add_development_dependency 'multipart_body'
-  s.add_development_dependency 'amqp', '>=0.7.1'
-  s.add_development_dependency 'em-websocket-client'
 
-  s.add_development_dependency 'tilt', '>=1.2.2'
-  s.add_development_dependency 'haml', '>=3.0.25'
-  s.add_development_dependency 'yard'
+  s.add_development_dependency 'em-http-request', '>=1.0.0'
+  s.add_development_dependency 'postrank-uri'
 
   s.add_development_dependency 'guard'
   s.add_development_dependency 'guard-rspec'
+  if RUBY_PLATFORM.include?('darwin')
+    s.add_development_dependency 'growl', '~> 1.0.3'
+    s.add_development_dependency 'rb-fsevent'
+  end
 
   if RUBY_PLATFORM != 'java'
     s.add_development_dependency 'yajl-ruby'
@@ -40,11 +36,6 @@ Gem::Specification.new do |s|
   else
     s.add_development_dependency 'json-jruby'
     s.add_development_dependency 'maruku'
-  end
-
-  if RUBY_PLATFORM.include?('darwin')
-    s.add_development_dependency 'growl', '~> 1.0.3'
-    s.add_development_dependency 'rb-fsevent'
   end
 
   ignores = File.readlines(".gitignore").grep(/\S+/).map {|i| i.chomp }

--- a/lib/goliath/contrib.rb
+++ b/lib/goliath/contrib.rb
@@ -1,11 +1,9 @@
+require 'goliath/contrib'
+
 # TODO: tries to start server :-)
 # require 'goliath'
 
 module Goliath
-  module Contrib
-  	VERSION = "1.0.0.beta1"
-  end
-
   # autoload :MiddlewareName, "goliath/contrib/middleware_name"
   # ...
 end

--- a/lib/goliath/contrib/rack/configurator.rb
+++ b/lib/goliath/contrib/rack/configurator.rb
@@ -1,0 +1,48 @@
+module Goliath
+  module Contrib
+    module Rack
+
+      # Place static values fron initialize into the env on each request
+      class StaticConfigurator
+        include Goliath::Rack::AsyncMiddleware
+
+        def initialize(app, env_vars)
+          @extra_env_vars = env_vars
+          super(app)
+        end
+
+        def call(env,*)
+          env.merge!(@extra_env_vars)
+          super
+        end
+      end
+
+      #
+      #
+      # @example imposes a timeout if 'rapid_timeout' param is present
+      #   class RapidServiceOrYour408Back < Goliath::API
+      #     use Goliath::Rack::Params
+      #     use ConfigurateFromParams, [:timeout], 'rapid'
+      #     use Goliath::Contrib::Rack::ForceTimeout
+      #   end
+      #
+      class ConfigurateFromParams
+        include Goliath::Rack::AsyncMiddleware
+
+        def initialize(app, param_keys, slug='')
+          @extra_env_vars = param_keys.inject({}){|acc,el| acc[el.to_sym] = [slug, el].join("_") ; acc }
+          super(app)
+        end
+
+        def call(env,*)
+          @extra_env_vars.each do |env_key, param_key|
+            # env.logger.info [env_key, param_key, env.params[param_key]]
+            env[env_key] ||= env.params.delete(param_key)
+          end
+          super
+        end
+      end
+
+    end
+  end
+end

--- a/lib/goliath/contrib/rack/diagnostics.rb
+++ b/lib/goliath/contrib/rack/diagnostics.rb
@@ -1,0 +1,46 @@
+module Goliath
+  module Contrib
+
+    module CaptureHeaders
+      # save client headers (only) into env[:client_headers]
+      def on_headers(env, headers)
+        env[:client_headers] = headers
+        super(env, headers) if defined?(super)
+      end
+    end
+
+    module Rack
+
+      #
+      # Add headers showing the request's parameters, path, headers and method
+      #
+      # You must also include Goliath::Contrib::CaptureHeaders in your responder class
+      #
+      # @example
+      #   class AwesomeService < Goliath::API
+      #     include Goliath::Contrib::CaptureHeaders
+      #     use     Goliath::Contrib::Rack::Diagnostics
+      class Diagnostics
+        include Goliath::Rack::AsyncMiddleware
+
+        def request_diagnostics(env)
+          client_headers = env[:client_headers] or env.logger.info("Please 'include Goliath::Contrib::CaptureHeaders' in your API class")
+          req_params  = env.params.collect{|param|     param.join(": ") }
+          req_headers = client_headers.collect{|param| param.join(": ") }
+          {
+            "X-Next"        => @app.class.name,
+            "X-Req-Params"  => req_params.join("|"),
+            "X-Req-Path"    => env[Goliath::Request::REQUEST_PATH],
+            "X-Req-Headers" => req_headers.join("|"),
+            "X-Req-Method"  => env[Goliath::Request::REQUEST_METHOD]}
+        end
+
+        def post_process env, status, headers, body
+          headers.merge!(request_diagnostics(env))
+          [status, headers, body]
+        end
+      end
+
+    end
+  end
+end

--- a/lib/goliath/contrib/rack/diagnostics.rb
+++ b/lib/goliath/contrib/rack/diagnostics.rb
@@ -44,7 +44,7 @@ module Goliath
             "X-Req-Params"  => req_params.join("|"),
             "X-Req-Path"    => env[Goliath::Request::REQUEST_PATH],
             "X-Req-Headers" => req_headers.join("|"),
-            "X-Req-Method"  => env[Goliath::Request::REQUEST_METHOD]}
+            "X-Req-Method"  => env[Goliath::Request::REQUEST_METHOD] }
         end
 
         def post_process env, status, headers, body

--- a/lib/goliath/contrib/rack/diagnostics.rb
+++ b/lib/goliath/contrib/rack/diagnostics.rb
@@ -1,6 +1,16 @@
 module Goliath
   module Contrib
 
+    # saves client headers into env[:client_headers]
+    #
+    # This is a module, not middleware: apps should `include` (not `use`) it.
+    # Also, please call 'super' if your app implements `on_headers`.
+    #
+    # @example
+    #   class AwesomeApp < Goliath::API
+    #     include Goliath::Contrib::CaptureHeaders
+    #   end
+    #
     module CaptureHeaders
       # save client headers (only) into env[:client_headers]
       def on_headers(env, headers)
@@ -14,19 +24,21 @@ module Goliath
       #
       # Add headers showing the request's parameters, path, headers and method
       #
-      # You must also include Goliath::Contrib::CaptureHeaders in your responder class
+      # Please also include Goliath::Contrib::CaptureHeaders in your app class.
       #
       # @example
-      #   class AwesomeService < Goliath::API
+      #   class AwesomeApp < Goliath::API
       #     include Goliath::Contrib::CaptureHeaders
       #     use     Goliath::Contrib::Rack::Diagnostics
+      #   end
+      #
       class Diagnostics
         include Goliath::Rack::AsyncMiddleware
 
         def request_diagnostics(env)
           client_headers = env[:client_headers] or env.logger.info("Please 'include Goliath::Contrib::CaptureHeaders' in your API class")
           req_params  = env.params.collect{|param|     param.join(": ") }
-          req_headers = client_headers.collect{|param| param.join(": ") }
+          req_headers = (client_headers||{}).collect{|param| param.join(": ") }
           {
             "X-Next"        => @app.class.name,
             "X-Req-Params"  => req_params.join("|"),

--- a/lib/goliath/contrib/rack/force_delay.rb
+++ b/lib/goliath/contrib/rack/force_delay.rb
@@ -3,18 +3,25 @@ module Goliath
 
     module Rack
 
-      # Delays response for `_delay + (0 to _randelay)` seconds, as given by the
-      # `_delay` and `_randelay` request parameters. Delays longer than 5
-      # seconds are clamped to 5 seconds.
+      # Delays response for `delay + (0 to randelay)` additional seconds after
+      # the app's response.
       #
       # This delay is non-blocking -- *other* requests may proceed in turn --
       # though naturally the call chain for this response doesn't proceed until
       # the delay is complete.
       #
-      # Information about the delay is added to the response headers for your enjoyment.
+      # ForceDelay ensures your response takes *at least* N seconds. Force
+      # Timeout ensures your response takes *at most* N seconds. To have a
+      # response take *as-close-as-reasonable-to* N seconds, use an N-second
+      # ForceTimeout with an (N+1)-second ForceDelay.
       #
-      # @example simulate a highly variable response time (min 0.5, max 1.5 seconds)
-      #   curl -v 'http://127.0.0.1:9000/?_delay=0.5&_randelay=1.0'
+      # The `force_delay` and `force_randelay` env variables specify the delay;
+      # values are clamped to be less than 5 seconds. Information about the
+      # delay is added to the response headers for your enjoyment.
+      #
+      # @example simulate a highly variable (0.5-1.5 sec) response time (see examples/test_rig.rb):
+      #   curl -v 'http://127.0.0.1:9000/?_force_delay=0.5&_force_randelay=1.0'
+      #   => Headers: X-Resp-Delay: 0.5 / X-Resp-Randelay: 1.0 / X-Resp-Actual: 0.90205979347229
       #
       class ForceDelay
         include Goliath::Rack::AsyncMiddleware
@@ -27,7 +34,6 @@ module Goliath
             be_sleepy(delay, randelay)
             actual = (Time.now.to_f - env[:start_time])
             headers.merge!( 'X-Resp-Delay' => delay.to_s, 'X-Resp-Randelay' => randelay.to_s, 'X-Resp-Actual' => actual.to_s )
-            body.merge!( :_delay_ms => delay, :_randelay_ms => randelay, :_actual_ms => actual, :_delay_start => env[:start_time].to_f )
           end
           [status, headers, body]
         end

--- a/lib/goliath/contrib/rack/force_delay.rb
+++ b/lib/goliath/contrib/rack/force_delay.rb
@@ -20,14 +20,14 @@ module Goliath
         include Goliath::Rack::AsyncMiddleware
 
         def post_process(env, status, headers, body)
-          delay    = env.params['_delay'].to_f
-          randelay = env.params['_randelay'].to_f
+          delay    = env[:force_delay].to_f
+          randelay = env[:force_randelay].to_f
           #
           if (delay > 0) || (randelay > 0)
             be_sleepy(delay, randelay)
             actual = (Time.now.to_f - env[:start_time])
             headers.merge!( 'X-Resp-Delay' => delay.to_s, 'X-Resp-Randelay' => randelay.to_s, 'X-Resp-Actual' => actual.to_s )
-            body.merge!( :_delay_ms => delay, :randelay_ms => randelay, :_actual_ms => actual )
+            body.merge!( :_delay_ms => delay, :_randelay_ms => randelay, :_actual_ms => actual )
           end
           [status, headers, body]
         end

--- a/lib/goliath/contrib/rack/force_delay.rb
+++ b/lib/goliath/contrib/rack/force_delay.rb
@@ -1,0 +1,45 @@
+module Goliath
+  module Contrib
+
+    module Rack
+
+      # Delays response for `_delay + (0 to _randelay)` seconds, as given by the
+      # `_delay` and `_randelay` request parameters. Delays longer than 5
+      # seconds are clamped to 5 seconds.
+      #
+      # This delay is non-blocking -- *other* requests may proceed in turn --
+      # though naturally the call chain for this response doesn't proceed until
+      # the delay is complete.
+      #
+      # Information about the delay is added to the response headers for your enjoyment.
+      #
+      # @example simulate a highly variable response time (min 0.5, max 1.5 seconds)
+      #   curl -v 'http://127.0.0.1:9000/?_delay=0.5&_randelay=1.0'
+      #
+      class ForceDelay
+        include Goliath::Rack::AsyncMiddleware
+
+        def post_process(env, status, headers, body)
+          delay    = env.params['_delay'].to_f
+          randelay = env.params['_randelay'].to_f
+          #
+          if (delay > 0) || (randelay > 0)
+            be_sleepy(delay, randelay)
+            actual = (Time.now.to_f - env[:start_time])
+            headers.merge!( 'X-Resp-Delay' => delay.to_s, 'X-Resp-Randelay' => randelay.to_s, 'X-Resp-Actual' => actual.to_s )
+            body.merge!( :_delay_ms => delay, :randelay_ms => randelay, :_actual_ms => actual )
+          end
+          [status, headers, body]
+        end
+
+        # sleep time limited to 5 seconds
+        def be_sleepy(delay, randelay)
+          total  = delay + (randelay * rand)
+          total  = [0, [total, 5].min].max # clamp
+          #
+          EM::Synchrony.sleep(total)
+        end
+      end
+    end
+  end
+end

--- a/lib/goliath/contrib/rack/force_delay.rb
+++ b/lib/goliath/contrib/rack/force_delay.rb
@@ -27,7 +27,7 @@ module Goliath
             be_sleepy(delay, randelay)
             actual = (Time.now.to_f - env[:start_time])
             headers.merge!( 'X-Resp-Delay' => delay.to_s, 'X-Resp-Randelay' => randelay.to_s, 'X-Resp-Actual' => actual.to_s )
-            body.merge!( :_delay_ms => delay, :_randelay_ms => randelay, :_actual_ms => actual )
+            body.merge!( :_delay_ms => delay, :_randelay_ms => randelay, :_actual_ms => actual, :_delay_start => env[:start_time].to_f )
           end
           [status, headers, body]
         end

--- a/lib/goliath/contrib/rack/force_drop.rb
+++ b/lib/goliath/contrib/rack/force_drop.rb
@@ -1,0 +1,38 @@
+module Goliath
+  module Contrib
+    module Rack
+
+      # Middleware to simulate dropping a connection.
+      #
+      # * if the _drop      parameter is given, close the connection as soon as possible
+      # * if the _drop_post parameter is given, close the connection late (after all following middlewares have happened)
+      #
+      # @example drop the connection immediately
+      #   curl 'http://localhost:9000/?_drop=true'
+      #
+      # @example wait one second then drop the connection with no response. Note that you must use `_drop_post`
+      #   curl 'http://localhost:9000/?_drop_post=true&_delay=1'
+      #
+      class ForceDrop
+        include Goliath::Rack::AsyncMiddleware
+
+        def call(env)
+          return super unless env.params['_drop'].to_s == 'true'
+
+          env.logger.info "Forcing dropped connection"
+          env.stream_close
+          [0, {}, {}]
+        end
+
+        def post_process(env, status, headers, body)
+          return super unless env.params['_drop_post'].to_s == 'true'
+
+          env.logger.info "Forcing dropped connection (after having run through other warez)"
+          env.stream_close
+          [0, {}, {}]
+        end
+
+      end
+    end
+  end
+end

--- a/lib/goliath/contrib/rack/force_drop.rb
+++ b/lib/goliath/contrib/rack/force_drop.rb
@@ -4,20 +4,20 @@ module Goliath
 
       # Middleware to simulate dropping a connection.
       #
-      # * if the _drop      parameter is given, close the connection as soon as possible
-      # * if the _drop_post parameter is given, close the connection late (after all following middlewares have happened)
+      # * if the _drop       env var is given, close the connection as soon as possible
+      # * if the _drop_after env var is given, close the connection late (after all following middlewares have happened)
       #
       # @example drop the connection immediately
       #   curl 'http://localhost:9000/?_drop=true'
       #
-      # @example wait one second then drop the connection with no response. Note that you must use `_drop_post`
-      #   curl 'http://localhost:9000/?_drop_post=true&_delay=1'
+      # @example wait one second then drop the connection with no response (note: `_drop_after`, not `_drop`)
+      #   curl 'http://localhost:9000/?_drop_after=true&_delay=1'
       #
       class ForceDrop
         include Goliath::Rack::AsyncMiddleware
 
         def call(env)
-          return super unless env.params['_drop'].to_s == 'true'
+          return super unless env[:force_drop].to_s == 'true'
 
           env.logger.info "Forcing dropped connection"
           env.stream_close
@@ -25,7 +25,7 @@ module Goliath
         end
 
         def post_process(env, status, headers, body)
-          return super unless env.params['_drop_post'].to_s == 'true'
+          return super unless env[:force_drop_after].to_s == 'true'
 
           env.logger.info "Forcing dropped connection (after having run through other warez)"
           env.stream_close

--- a/lib/goliath/contrib/rack/force_drop.rb
+++ b/lib/goliath/contrib/rack/force_drop.rb
@@ -4,14 +4,18 @@ module Goliath
 
       # Middleware to simulate dropping a connection.
       #
-      # * if the _drop       env var is given, close the connection as soon as possible
-      # * if the _drop_after env var is given, close the connection late (after all following middlewares have happened)
+      # * if the force_drop       env var is given, close the connection as soon as possible
+      # * if the force_drop_after env var is given, close the connection late (after all following middlewares have happened)
       #
-      # @example drop the connection immediately
-      #   curl 'http://localhost:9000/?_drop=true'
+      # @example drop the connection immediately (see examples/test_rig.rb):
+      #   time curl 'http://localhost:9000/?_force_drop=true'
+      #   => curl: (52) Empty reply from server
+      #   real  0m0.027s        user    0m0.008s        sys     0m0.005s
       #
-      # @example wait one second then drop the connection with no response (note: `_drop_after`, not `_drop`)
-      #   curl 'http://localhost:9000/?_drop_after=true&_delay=1'
+      # @example drop the connection with no response after waiting one second; the delay is provided by the `ForceDelay` middleware in `_drop_after` mode:
+      #   time curl 'http://localhost:9000/?_drop_after=true&_delay=1'
+      #   => curl: (52) Empty reply from server
+      #   real  0m1.111s        user    0m0.008s        sys     0m0.005s
       #
       class ForceDrop
         include Goliath::Rack::AsyncMiddleware

--- a/lib/goliath/contrib/rack/force_fault.rb
+++ b/lib/goliath/contrib/rack/force_fault.rb
@@ -1,12 +1,18 @@
 module Goliath
 
   module Validation ; class InjectedError < Error ; end ; end
-  
+
   module Contrib
     module Rack
 
-      # if either the '_fail_pre' or '_fail_after' parameter is given, raise an error
-      # The parameter's value (as an integer) becomes the response code
+      # if either the 'force_fault' or 'force_fault_after' env attribute are
+      # given, raise an error. The attribute's value (as an integer) becomes the
+      # response code.
+      #
+      # @example simulate a 503 (see `examples/test_rig.rb`):
+      #   curl -v 'http://127.0.0.1:9000/?_force_fault=503'
+      #   => {"status":503,"error":"ServiceUnavailableError","message":"Injected middleware fault 503"}
+      #
       class ForceFault
         include Goliath::Rack::AsyncMiddleware
 

--- a/lib/goliath/contrib/rack/force_fault.rb
+++ b/lib/goliath/contrib/rack/force_fault.rb
@@ -5,21 +5,21 @@ module Goliath
   module Contrib
     module Rack
 
-      # if either the '_fail_pre' or '_fail_post' parameter is given, raise an error
+      # if either the '_fail_pre' or '_fail_after' parameter is given, raise an error
       # The parameter's value (as an integer) becomes the response code
       class ForceFault
         include Goliath::Rack::AsyncMiddleware
 
         def call(env)
-          if code = env.params['_fault']
-            raise Goliath::Validation::InjectedError.new(code.to_i, "Injected middleware fault #{code}")
+          if fault_code = env[:force_fault]
+            raise Goliath::Validation::InjectedError.new(fault_code.to_i, "Injected middleware fault #{fault_code}")
           end
           super
         end
 
         def post_process(env, *)
-          if code = env.params['_fault_post']
-            raise Goliath::Validation::InjectedError.new(code.to_i, "Injected middleware fault #{code} (after response was composed)")
+          if fault_code = env[:force_fault_after]
+            raise Goliath::Validation::InjectedError.new(fault_code.to_i, "Injected middleware fault #{fault_code} (after response was composed)")
           end
           super
         end

--- a/lib/goliath/contrib/rack/force_fault.rb
+++ b/lib/goliath/contrib/rack/force_fault.rb
@@ -1,0 +1,31 @@
+module Goliath
+
+  module Validation ; class InjectedError < Error ; end ; end
+  
+  module Contrib
+    module Rack
+
+      # if either the '_fail_pre' or '_fail_post' parameter is given, raise an error
+      # The parameter's value (as an integer) becomes the response code
+      class ForceFault
+        include Goliath::Rack::AsyncMiddleware
+
+        def call(env)
+          if code = env.params['_fault']
+            raise Goliath::Validation::InjectedError.new(code.to_i, "Injected middleware fault #{code}")
+          end
+          super
+        end
+
+        def post_process(env, *)
+          if code = env.params['_fault_post']
+            raise Goliath::Validation::InjectedError.new(code.to_i, "Injected middleware fault #{code} (after response was composed)")
+          end
+          super
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/goliath/contrib/rack/force_response.rb
+++ b/lib/goliath/contrib/rack/force_response.rb
@@ -2,16 +2,15 @@ module Goliath
   module Contrib
     module Rack
 
-      # if _status, _headers or _body are given, blindly substitute their
-      # value, clobbering whatever was there.
-      #
-      # If you are going to use _headers you probably need to use a JSON post body.
+      # if force_status, force_headers or force_body env attributes are present,
+      # blindly substitute the attribute's value, clobbering whatever was there.
       #
       # @example setting headers with a JSON post body
-      #   curl -v -H "Content-Type: application/json" --data-ascii '{"_headers":{"X-Question":"What is brown and sticky"},"_body":{"answer":"a stick"}}' 'http://127.0.0.1:9001/'
+      #   curl -v -H "Content-Type: application/json" --data-ascii '{"_force_headers":{"X-Question":"What is brown and sticky"},"_force_body":{"answer":"a stick"}}' 'http://127.0.0.1:9001/'
+      #   => {"answer":"a stick"}
       #
-      # @example forcing a boring response body so ab doesn't whine about a varying response body size
-      #   ab -n 10000 -c 100  'http://localhost:9000/?_delay=0.4&_randelay=0.01&_body=OK'
+      # @example force a boring response body so ab doesn't whine about a varying response body size:
+      #   ab -n 10000 -c 100  'http://localhost:9000/?_force_body=OK'
       #
       class ForceResponse
         include Goliath::Rack::AsyncMiddleware

--- a/lib/goliath/contrib/rack/force_response.rb
+++ b/lib/goliath/contrib/rack/force_response.rb
@@ -17,9 +17,9 @@ module Goliath
         include Goliath::Rack::AsyncMiddleware
 
         def post_process(env, status, headers, body)
-          if (force_status  = env.params['_status'])  then  status  = force_status.to_i ; end
-          if (force_headers = env.params['_headers']) then  headers = force_headers     ; end
-          if (force_body    = env.params['_body'])    then  body    = force_body        ; end
+          if (force_status  = env[:force_status])  then  status  = force_status.to_i ; end
+          if (force_headers = env[:force_headers]) then  headers = force_headers     ; end
+          if (force_body    = env[:force_body])    then  body    = force_body        ; end
           [status, headers, body]
         end
 

--- a/lib/goliath/contrib/rack/force_response.rb
+++ b/lib/goliath/contrib/rack/force_response.rb
@@ -1,0 +1,29 @@
+module Goliath
+  module Contrib
+    module Rack
+
+      # if _status, _headers or _body are given, blindly substitute their
+      # value, clobbering whatever was there.
+      #
+      # If you are going to use _headers you probably need to use a JSON post body.
+      #
+      # @example setting headers with a JSON post body
+      #   curl -v -H "Content-Type: application/json" --data-ascii '{"_headers":{"X-Question":"What is brown and sticky"},"_body":{"answer":"a stick"}}' 'http://127.0.0.1:9001/'
+      #
+      # @example forcing a boring response body so ab doesn't whine about a varying response body size
+      #   ab -n 10000 -c 100  'http://localhost:9000/?_delay=0.4&_randelay=0.01&_body=OK'
+      #
+      class ForceResponse
+        include Goliath::Rack::AsyncMiddleware
+
+        def post_process(env, status, headers, body)
+          if (force_status  = env.params['_status'])  then  status  = force_status.to_i ; end
+          if (force_headers = env.params['_headers']) then  headers = force_headers     ; end
+          if (force_body    = env.params['_body'])    then  body    = force_body        ; end
+          [status, headers, body]
+        end
+
+      end
+    end
+  end
+end

--- a/lib/goliath/contrib/rack/force_timeout.rb
+++ b/lib/goliath/contrib/rack/force_timeout.rb
@@ -5,6 +5,18 @@ module Goliath
       #
       # Force a timeout after given number of seconds
       #
+      # ForceTimeout ensures your response takes *at most* N seconds. ForceDelay
+      # ensures your response takes *at least* N seconds. To have a response
+      # take *as-close-as-reasonable-to* N seconds, use an N-second ForceTimeout
+      # with an (N+1)-second ForceDelay.
+      #
+      #
+      # @example first call is 200 OK, second will error with 408 RequestTimeoutError (see examples/test_rig.rb):
+      #   curl -v 'http://127.0.0.1:9000/?_force_timeout=1.0&_force_delay=0.5'
+      #   => Headers: X-Resp-Delay: 0.5 / X-Resp-Randelay: 0.0 / X-Resp-Actual: 0.513401985168457 / X-Resp-Timeout: 1.0
+      #   curl -v 'http://127.0.0.1:9000/?_force_timeout=1.0&_force_delay=2.0'
+      #   => {"status":408,"error":"RequestTimeoutError","message":"Request exceeded 1.0 seconds"}
+      #
       class ForceTimeout
         include Goliath::Rack::Validator
 
@@ -28,6 +40,7 @@ module Goliath
             env['async.callback'] = Proc.new do |status, headers, body|
               unless env[:force_timeout_complete]
                 env[:force_timeout_complete] = true
+                headers.merge!('X-Resp-Timeout' => timeout.to_s)
                 async_cb.call([status, headers, body])
               end
             end
@@ -36,7 +49,11 @@ module Goliath
             # This will always fire, we just don't do anything if already handled.
             # If not handled elsewhere, mark as handled and raise an error
             EM.add_timer(timeout) do
-              async_cb.call(safely(env){ handle_timeout(env, timeout) })
+              unless env[:force_timeout_complete]
+                env[:force_timeout_complete] = true
+                err = Goliath::Validation::RequestTimeoutError.new("Request exceeded #{timeout} seconds")
+                async_cb.call(error_response(err, 'X-Resp-Timeout' => timeout.to_s))
+              end
             end
           end
 
@@ -48,12 +65,6 @@ module Goliath
           [status, headers, body]
         end
 
-        def handle_timeout(env, timeout)
-          unless env[:force_timeout_complete]
-            env[:force_timeout_complete] = true
-            raise Goliath::Validation::RequestTimeoutError.new("Request exceeded #{timeout} seconds")
-          end
-        end
       end
     end
   end

--- a/lib/goliath/contrib/rack/force_timeout.rb
+++ b/lib/goliath/contrib/rack/force_timeout.rb
@@ -1,0 +1,60 @@
+module Goliath
+  module Contrib
+    module Rack
+
+      #
+      # Force a timeout after given number of seconds
+      #
+      class ForceTimeout
+        include Goliath::Rack::Validator
+
+        # @param app [Proc] The application
+        # @return [Goliath::Rack::AsyncMiddleware]
+        def initialize(app)
+          @app     = app
+        end
+
+        # @param env [Goliath::Env] The goliath environment
+        # @return [Array] The [status_code, headers, body] tuple
+        def call(env, *args)
+          timeout = [0.0, [env[:force_timeout].to_f, 10.0].min].max
+
+          if (timeout != 0.0)
+            async_cb = env['async.callback']
+            env[:force_timeout_complete] = false
+
+            # Normal callback, executed by downstream middleware
+            # If not handled elsewhere, mark as handled and pass along unchanged
+            env['async.callback'] = Proc.new do |status, headers, body|
+              unless env[:force_timeout_complete]
+                env[:force_timeout_complete] = true
+                async_cb.call([status, headers, body])
+              end
+            end
+
+            # timeout callback, executed by EM timer.
+            # This will always fire, we just don't do anything if already handled.
+            # If not handled elsewhere, mark as handled and raise an error
+            EM.add_timer(timeout) do
+              async_cb.call(safely(env){ handle_timeout(env, timeout) })
+            end
+          end
+
+          status, headers, body = @app.call(env)
+
+          if status == Goliath::Connection::AsyncResponse.first
+            env[:force_timeout_complete] = true
+          end
+          [status, headers, body]
+        end
+
+        def handle_timeout(env, timeout)
+          unless env[:force_timeout_complete]
+            env[:force_timeout_complete] = true
+            raise Goliath::Validation::RequestTimeoutError.new("Request exceeded #{timeout} seconds")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/goliath/contrib/rack/handle_exceptions.rb
+++ b/lib/goliath/contrib/rack/handle_exceptions.rb
@@ -39,9 +39,9 @@ module Goliath
           })
         headers.delete('Content-Length')
         body    = {
-          "error"   => err.class.to_s.gsub(/.*::/,""),
-          "message" => err.message,
-          "status"  => err.status_code
+          status:  err.status_code,
+          error:   err.class.to_s.gsub(/.*::/,"/"),
+          message: err.message,
         }
         [err.status_code, headers, body]
       end

--- a/lib/goliath/contrib/rack/handle_exceptions.rb
+++ b/lib/goliath/contrib/rack/handle_exceptions.rb
@@ -1,0 +1,51 @@
+module Goliath
+  module Contrib
+    module Rack
+
+      # Rescue validation errors in the app just as you do
+      # in middleware
+      class HandleExceptions
+        include Goliath::Rack::AsyncMiddleware
+        include Goliath::Rack::Validator
+        def call(env)
+          safely(env){ super }
+        end
+      end
+
+    end
+  end
+
+  module Rack
+    module Validator
+      module_function
+
+      # @param status_code [Integer] HTTP status code for this error.
+      # @param msg [String] message to inject into the response body.
+      # @param headers [Hash] Response headers to preserve in an error response;
+      #   (the Content-Length header, if any, is removed)
+      def validation_error(status_code, msg, headers={})
+        err_class = Goliath::HTTP_ERRORS[status_code.to_i]
+        err = err_class ? err_class.new(msg) : Goliath::Validation::Error.new(status_code, msg)
+        error_response(err, headers)
+      end
+
+      # @param err [Goliath::Validation::Error] error to describe in response
+      # @param headers [Hash] Response headers to preserve in an error response;
+      #   (the Content-Length header, if any, is removed)
+      def error_response(err, headers={})
+        headers.merge!({
+            'X-Error-Message' => err.class.default_message,
+            'X-Error-Detail'  => err.message,
+          })
+        headers.delete('Content-Length')
+        body    = {
+          "error"   => err.class.to_s.gsub(/.*::/,""),
+          "message" => err.message,
+          "status"  => err.status_code
+        }
+        [err.status_code, headers, body]
+      end
+
+    end
+  end
+end

--- a/lib/goliath/contrib/rack/handle_exceptions.rb
+++ b/lib/goliath/contrib/rack/handle_exceptions.rb
@@ -4,14 +4,26 @@ module Goliath
 
       # Rescue validation errors in the app just as you do
       # in middleware
+      #
+      # Place this as early as possible in the request chain, but after the rendering.
+      #
+      # @example For JSON-encoded responses, good and bad:
+      #   class AwesomeApp < Goliath::API
+      #     use Goliath::Rack::DefaultMimeType           # cleanup accepted media types
+      #     use Goliath::Rack::Render, 'json'            # auto-negotiate response format
+      #     use Goliath::Contrib::Rack::HandleExceptions # turn raised errors into HTTP responses
+      #     use Goliath::Rack::Params                    # parse & merge query and body parameters
+      #     # ... awesomeness goes here ...
+      #   end
+      #
       class HandleExceptions
         include Goliath::Rack::AsyncMiddleware
         include Goliath::Rack::Validator
+
         def call(env)
           safely(env){ super }
         end
       end
-
     end
   end
 
@@ -40,7 +52,7 @@ module Goliath
         headers.delete('Content-Length')
         body    = {
           status:  err.status_code,
-          error:   err.class.to_s.gsub(/.*::/,"/"),
+          error:   err.class.to_s.gsub(/.*::/,""),
           message: err.message,
         }
         [err.status_code, headers, body]

--- a/lib/goliath/contrib/version.rb
+++ b/lib/goliath/contrib/version.rb
@@ -1,0 +1,5 @@
+module Goliath
+  module Contrib
+    VERSION = "1.0.0.beta1"
+  end
+end

--- a/spec/goliath/contrib_spec.rb
+++ b/spec/goliath/contrib_spec.rb
@@ -1,0 +1,6 @@
+
+describe Goliath::Contrib do
+  it 'has a version' do
+    Goliath::Contrib::VERSION.should be_a(String)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,14 @@
+require 'bundler'
+
+Bundler.setup
+Bundler.require
+
+require 'goliath/test_helper'
+
+Goliath.env = :test
+
+RSpec.configure do |c|
+  c.include Goliath::TestHelper, :example_group => {
+    :file_path => /spec\/integration/
+  }
+end


### PR DESCRIPTION
Middlewares to do many useful forms of diagnosis and fault injection:
- force_delay       does a 'sleep for x +- y' seconds before responding
- force_drop        drops the connection, before or after its middleware descendents run
- force_fault       raises the requested type of error (eg _fault=404 will bail out of the rpocessing chain, returning a 404 Not Found response
- force_response    forcibly replaces the status, headers or body with what's given in the URL
- handle_exceptions gives you response methods, same that the middleware provides, for your app
- diagnostics recycles info about the request into the output

I don't seem to know how to do these as individual pull requests
