### PR TITLE
Son of a batch: lets one request to an endpoint become dozens of concurrent requests to remote sites

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,10 @@ gemspec
 
 gem 'goliath', :path => '../goliath'
 
+group :development do
+  gem 'rake'
+end
+
 # Gems for testing and coverage
 group :test do
   gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,14 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in goliath-contrib.gemspec
 gemspec
+
+gem 'goliath', :path => '../goliath'
+
+# Gems for testing and coverage
+group :test do
+  gem 'pry'
+  gem 'rspec'
+  gem 'guard'
+  gem 'guard-rspec'
+  gem 'guard-yard'
+end

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,20 @@
+# -*- ruby -*-
+
+format = 'progress' # 'doc' for more verbose, 'progress' for less
+tags   = %w[ ]
+guard 'rspec', :version => 2, :cli => "--format #{format} #{ tags.map{|tag| "--tag #{tag}"}.join(' ')  }" do
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^lib/(.+)\.rb$})           { |m| "spec/#{m[1]}_spec.rb"  }
+  watch(%r{^examples/(.+)\.rb$})      { |m| "spec/integration/#{m[1]}_spec.rb" }
+
+  watch('spec/spec_helper.rb')         { 'spec' }
+  watch(/spec\/support\/(.+)\.rb/)     { 'spec' }
+end
+
+group :docs do
+  guard 'yard' do
+    watch(%r{app/.+\.rb})
+    watch(%r{lib/.+\.rb})
+    watch(%r{ext/.+\.c})
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,27 @@
-#!/usr/bin/env rake
-require "bundler/gem_tasks"
+require 'bundler'
+Bundler::GemHelper.install_tasks
+
+require 'yard'
+require 'rspec/core/rake_task'
+require 'rake/testtask'
+
+task :default => [:test]
+task :test => [:spec, :unit]
+
+desc "run the unit test"
+Rake::TestTask.new(:unit) do |t|
+   t.libs << "test"
+   t.test_files = FileList['test/**/*_test.rb']
+   t.verbose = true
+end
+
+desc "run spec tests"
+RSpec::Core::RakeTask.new('spec') do |t|
+  t.pattern = 'spec/**/*_spec.rb'
+end
+
+desc 'Generate documentation'
+YARD::Rake::YardocTask.new do |t|
+  t.files   = ['lib/**/*.rb', '-', 'LICENSE']
+  t.options = ['--main', 'README.md', '--no-private']
+end

--- a/examples/fiber_magic_explained.rb
+++ b/examples/fiber_magic_explained.rb
@@ -1,0 +1,85 @@
+#!/usr/bin/env ruby
+require 'fiber'
+require 'eventmachine'
+
+FIBER_IDXS = {}
+
+def fiber_idx
+  FIBER_IDXS[Fiber.current.object_id] ||= FIBER_IDXS.length
+end
+
+$order = 0
+
+def ll indent, where, guess, desc
+  info = (fiber_idx == 0 ? "#{" "*indent} #{where} #{" "*20}" : "#{" "*(indent+20)} #{where}")
+  $stderr.puts "%8s %3d  %-10s  %3d %-40s\t%s" % [
+    Fiber.current.object_id.to_s(16),
+    $order,
+    guess,
+    fiber_idx,
+    info,
+    desc
+  ]
+  $order += 1
+end
+
+#
+# Start reading in the eventmachine block below, then come back here
+#
+
+def get_result()
+  ll(4, 'beg get_result',      " 6 fiber_1", "Beg get_result: this is called from within fiber_1")
+  f = Fiber.current
+
+  ll(4, 'setup callback',      " 7 fiber_1", "Pre 1.5s timer: set up some code to run 1.5s from now")
+  EM.add_timer(1.5) do
+    ll(5, 'beg callback',      "10 fiber_0", "Beg 1.5s timer: Executed *by the main fiber* 1.5 seconds from 'setup callback'; all non-deferred code from the EventMachine.run{} setup block has happened")
+
+    ll(5, 'fiber.resume',      "11 fiber_0", "fiber.resume(:bob): picks up where the fiber left off ('ret = Fiber.yield'), giving it the value ':bob'")
+    f.resume(:bob)
+
+    ll(5, 'end callback',      "15 fiber_0", "End 1.5s timer: the callback is done, and so is the fiber, leaving only the EM.stop block on the reactor.")
+  end
+
+  ll(4, 'Fiber.yield',         " 8 fiber_1", "EM.add_timer just stashed away the 1.5s timer's block, so this runs next.")
+  ret = Fiber.yield            #   fiber_1 -- Suspends action until fiber.resume called
+  ll(4, "fiber result",        "12 fiber_1", "fiber result: '#{ret}' f.resume picks up here when the timer goes off.")
+
+  ll(4, "end get_result",      "13 fiber_1", "end of function call")
+  return ret
+end
+
+
+#
+# Start here:
+#
+ll(0, 'beg main',              " 0 fiber_0", "top level")
+
+EventMachine.run do
+  ll(1, 'beg em setup',        " 1 fiber_0", "Eventmachine execution has begun; lines following this block aren't run until EM.stop is called")
+
+  EM.add_timer(2.5){
+    ll(2, "stop runner",       "17 fiber_0", "EM stop: 2.5s into the future, stop the Eventmachine reactor. The next to last thing in the program... ")
+    EM.stop
+  }
+
+  ll(2, 'beg fiber setup',     " 2 fiber_0", "Pre fiber: the end-the-reactor block won't be called for 1.5s, so we get here immediately.")
+
+  my_fiber = Fiber.new{
+    ll(3, 'beg fiber',         " 5 fiber_1", "Beg fiber: runs when my_fiber.resume is called the first time. Am now in a new fiber.")
+
+    res = get_result()        #    fiber1 -- get_result is called, but the last thing it does is pause execution
+
+    ll(3, "got it: '#{res}'",  "14 fiber_1", "get_result returned '#{res}'")
+    ll(3, "end fiber",         "15 fiber_1", "End fiber: picks up in timer callback, site of the last 'f.resume'")
+  }
+
+  ll(2, 'end fiber setup',     " 3 fiber_0", "nothing from inside the Fiber.new{} block has run yet.")
+
+  ll(2, 'fiber.resume',        " 4 fiber_0", "first fiber.resume...")
+  my_fiber.resume
+
+  ll(1, 'end em setup',        " 9 fiber_0", "the line after my_fiber.resume, picks up when 'ret = Fiber.yield' is called. Now we go into the reactor loop and twiddle our thumbs for 1.5s")
+end
+
+ll(0, 'end main',              "18 fiber_0", "done.")

--- a/examples/son_of_a_batch.rb
+++ b/examples/son_of_a_batch.rb
@@ -1,0 +1,192 @@
+#!/usr/bin/env ruby
+
+require 'postrank-uri'
+require 'set'
+require 'goliath'
+require 'em-synchrony/em-http'
+
+require 'goliath/contrib/rack/configurator'
+require 'goliath/contrib/rack/diagnostics'
+require 'goliath/contrib/rack/handle_exceptions'
+
+require 'gorillib/object/blank'
+require 'goliath/contrib/rack/handle_exceptions'
+require 'goliath/contrib/rack/batch_iterator'
+
+require 'rack/mime'
+Rack::Mime::MIME_TYPES['.tsv'] = "text/tsv"
+
+# The examples use the test_rig from goliath-contrib:
+#
+#     bundle exec ./examples/test_rig.rb       -s -p 9000 -e production &
+#     bundle exec ./examples/son_of_a_batch.rb -s -p 9004 -e production
+#
+# It gives us a target that can simulate a variable delay, dropped connections, server faults, and so forth.
+#
+# In the first example, son_of_a_batch is called with the default batch timeout
+# of 2.0sec and concurrency 10.  If you run the curl command given below, you
+# will see that the responses roll in as they are received:
+#
+# * req 0 delay 1.5  -- the last `OK` response sent, even though it was the first dispatched.
+# * req 1 delay 2.3  -- causes an `ETIMEDOUT` error on the son_of_a_batch side
+# * req 2 delay 1.02 -- arrives after the next two requests -- they are launched at effectively the same time
+# * req 3 delay 1    -- first among the `OK`'s
+# * req 4 delay 1    -- second among the `OK`'s
+# * req 5 delay 4.0  -- causes an `ETIMEDOUT` error on the son_of_a_batch side
+#
+# @example a simple get batch (many params against one host)
+#   curl -v 'http://localhost:9004/batch.json?url_base=http%3A%2F%2Flocalhost%3A9000%2F%3F_force_delay%3D&url_vals=1.5,2.3,1.02,1,1,4.0'
+#   =>
+#       {
+#       "results":\{
+#       "3":{"status":200,"body":"{\"_delay_ms\":1.0,\"_randelay_ms\":0.0,\"_actual_ms\":1.0118811130523682,\"_delay_start\":1340566341.449735}"},
+#       "4":{"status":200,"body":"{\"_delay_ms\":1.0,\"_randelay_ms\":0.0,\"_actual_ms\":1.008415937423706,\"_delay_start\":1340566341.4538581}"},
+#       "2":{"status":200,"body":"{\"_delay_ms\":1.02,\"_randelay_ms\":0.0,\"_actual_ms\":1.1126141548156738,\"_delay_start\":1340566341.441438}"},
+#       "0":{"status":200,"body":"{\"_delay_ms\":1.5,\"_randelay_ms\":0.0,\"_actual_ms\":1.5765349864959717,\"_delay_start\":1340566341.434098}"},
+#       "_":{}},
+#       "stats":{"duration":2.013,"queries":6,"concurrency":10,"inactivity_timeout":"2.0","connect_timeout":"2.0","batch_id":36},
+#       "errors":{"1":[400,{},"Errno::ETIMEDOUT"],"5":[400,{},"Errno::ETIMEDOUT"]}
+#       }
+# __________________________________________________________________________
+#
+# In the second example, son_of_a_batch is called using a JSON post body, but still using the simple `url_vals` iterator.
+#
+# 1.5,2.3,0.3&_force_fault=503,0.3&_force_drop=true,1.02,1,1,4.0
+# * req 0 delay 1.5  -- the next-to-last `OK` response sent, even though it was the first dispatched.
+# * req 1 delay 2.3  -- succeeds, because we increased the `batch_timeout`
+# * req 2 delay 0.3 and _force_fault=503 -- returns immediately with a *successful* (to son_of_a_batch) 503 response.
+# * req 3 delay 0.3 and _force_drop=true -- drops connection immediately, so it's an error (to son_of_a_batch) that it can't explain
+# * req 4 delay 1.02 -- arrives after the next two requests -- they are launched at effectively the same time
+# * req 5 delay 1    -- first among the `OK`'s
+# * req 6 delay 1    -- second among the `OK`'s
+# * req 7 delay 4.0  -- causes an `ETIMEDOUT` error on the son_of_a_batch side
+#
+# @example a get batch (JSON request)
+#   curl -v -H "Content-Type: application/json" --data-ascii '{ "batch_timeout":2.5, "url_base":"http://localhost:9000/?_force_delay=", "url_vals":"1.5,2.3,0.3&_force_fault=503,0.3&_force_drop=true,1.02,1,1,4.0" }' 'http://localhost:9004/batch.json'
+#   =>
+#       {
+#       "results":\{
+#       "2":{"status":503,"body":"{\"status\":503,\"error\":\"ServiceUnavailableError\",\"message\":\"Injected middleware fault 503\"}"},
+#       "5":{"status":200,"body":"{\"_delay_ms\":1.0,\"_randelay_ms\":0.0,\"_actual_ms\":1.011551856994629,\"_delay_start\":1340566961.8383281}"},
+#       "6":{"status":200,"body":"{\"_delay_ms\":1.0,\"_randelay_ms\":0.0,\"_actual_ms\":1.0085508823394775,\"_delay_start\":1340566961.84186}"},
+#       "4":{"status":200,"body":"{\"_delay_ms\":1.02,\"_randelay_ms\":0.0,\"_actual_ms\":1.107508897781372,\"_delay_start\":1340566961.834423}"},
+#       "0":{"status":200,"body":"{\"_delay_ms\":1.5,\"_randelay_ms\":0.0,\"_actual_ms\":1.5890910625457764,\"_delay_start\":1340566961.807979}"},
+#       "1":{"status":200,"body":"{\"_delay_ms\":2.3,\"_randelay_ms\":0.0,\"_actual_ms\":2.3053030967712402,\"_delay_start\":1340566961.821911}"},
+#       "_":{}},
+#       "stats":{"duration":2.516,"queries":8,"concurrency":10,"inactivity_timeout":"2.5","connect_timeout":"2.5","batch_id":37},
+#       "errors":{"3":[400,{},"no_response"],"7":[400,{},"Errno::ETIMEDOUT"]}
+#       }
+#
+# @example Arbitrary assemblage of URLs (all hosts must be whitelisted)
+#
+#   APIKEY=XXXXX # http://www.infochimps.com/documentation
+#   curl -v -H "Content-Type: application/json" --data-ascii '{"urls":{
+#         "food":"http://api.infochimps.com/social/network/tw/token/word_stats?_apikey='$APIKEY'&tok=food",
+#         "drink":"http://api.infochimps.com/social/network/tw/token/word_stats?_apikey='$APIKEY'&tok=drink",
+#         "sex":"http://api.infochimps.com/social/network/tw/token/word_stats?_apikey='$APIKEY'&tok=sex",
+#         "bieber":"http://api.infochimps.com/social/network/tw/token/word_stats?_apikey='$APIKEY'&tok=bieber"
+#       }' 'http://localhost:9004/batch.json'
+#
+# @example Using son of a batch to automate commandline data analysis. I won't try to justify this mode of work, but you might enjoy taking it apart to understand it:
+#
+#   APIKEY=XXXXX # http://www.infochimps.com/documentation
+#   curl -v -H "Content-Type: application/json" --data-ascii '{"batch_timeout":1.9,"url_base":"http://api.infochimps.com/social/network/tw/token/word_stats?_apikey='$APIKEY'&tok=","url_vals":"bieber,cars,cats,shoes,java,love,money,sex"}' 'http://localhost:9004/batch.tsv' | grep '^_r' | ruby -rjson -ne 'raw_resp = $_.split("\t",4).last; resp = JSON.parse(raw_resp); puts [resp["tok"], resp["total_usages"]].join("\t")' | sort -nk2
+#   =>
+#     java        522351.0
+#     cats        838706.0
+#     cars       1150704.0
+#     shoes      1623588.0
+#     bieber     1700116.0
+#     sex        3695956.0
+#     money      9496697.0
+#     love      64208941.0
+#   # bieber is more popular than shoes, and love is stronger than money.
+#
+class SonOfABatch < Goliath::API
+  include Goliath::Validation
+  include Goliath::Contrib::CaptureHeaders
+  use Goliath::Rack::Heartbeat                 # respond to /status with 200, OK (monitoring, etc)
+  use Goliath::Rack::Tracer                    # log trace statistics
+  use Goliath::Rack::DefaultMimeType           # cleanup accepted media types
+  use Goliath::Rack::Render, 'json'            # auto-negotiate response format
+  use Goliath::Contrib::Rack::HandleExceptions # turn raised errors into HTTP responses
+  use Goliath::Rack::Params                    # parse & merge query and body parameters
+
+  use Goliath::Contrib::Rack::Diagnostics      # summarize the request in the response headers
+
+  HOST_WHITELIST = %w[ api.infochimps.com localhost 127.0.0.1 ].to_set unless defined?(HOST_WHITELIST)
+  MIN_TIMEOUT =  2.0 unless defined?(MIN_TIMEOUT) # seconds
+  MAX_TIMEOUT = 10.0 unless defined?(MAX_TIMEOUT) # seconds
+
+  # Acceptable characters in a request ID
+  IDENTIFIER_OR_NUM_RE = /\A[a-zA-Z0-9]\w*\z/ unless defined?(IDENTIFIER_OR_NUM_RE)
+
+  def initialize
+    super
+    @next_batch_id = 0
+  end
+
+  def response(env)
+    requestor =
+      case
+      when env['PATH_INFO'] =~ %r{/batch\.json$} then JsonBatchIterator
+      when env['PATH_INFO'] =~ %r{/batch\.tsv$}  then TsvBatchIterator
+      else raise NotAcceptableError, "Only .json and .tsv are supported for son_of_a_batch"
+      end
+    @next_batch_id += 1
+    headers = {'X-Responder' => self.class.to_s, 'X-Sob-Timeout' => timeout.to_s }
+
+    # launch the requests; response will stream back asynchronously
+    requestor.new(env, @next_batch_id, timeout, queries).perform
+    chunked_streaming_response(200, headers)
+  end
+
+protected
+
+  # @return [nil, Float] time to wait for responses, or nil for no timeout. Clamped to MIN_TIMEOUT..MAX_TIMEOUT seconds
+  def timeout
+    timeout = params['batch_timeout'].to_f
+    (timeout == 0) ? MAX_TIMEOUT : [MIN_TIMEOUT, [timeout, MAX_TIMEOUT].min].max
+  end
+
+  # Turn the raw params hash into actionable values.
+  def queries
+    urls, url_base, url_vals = params.values_at('urls', 'url_base', 'url_vals')
+
+    if urls && urls.is_a?(Hash)
+      # the outcome of a json-encoded POST body
+      raw_queries = urls
+
+    elsif url_base && url_vals
+      # assemble queries by slapping each url_val on the end of url_base
+      raise BadRequestError, "url_base must be a string" unless url_base.is_a?(String)
+      raise BadRequestError, "url_vals must be an array or comma-delimited string" unless url_vals.is_a?(String) || url_vals.is_a?(Array)
+      url_vals = url_vals.split(',') if url_vals.is_a?(String)
+      #
+      raw_queries = {}
+      url_vals.each_with_index do |val, idx|
+        raw_queries[idx] = "#{url_base}#{val}"
+      end
+    else
+      raise BadRequestError, "Need either url_base and url_vals, or a JSON post body giving a hash of req_id:url pairs."
+    end
+
+    # make all the queries safe
+    normalized_queries = {}
+    raw_queries.each do |req_id, raw_q|
+      raise BadRequestError, "Request IDs must be numbers or simple identifiers" unless (req_id.to_s =~ IDENTIFIER_OR_NUM_RE)
+      norm_q = normalize_query(raw_q) or next
+      normalized_queries[req_id.to_s] = norm_q
+    end
+    normalized_queries
+  end
+
+  # light safety and normalization for the url string
+  def normalize_query url
+    url = PostRank::URI.normalize(url) rescue nil
+    return if url.blank?
+    return if url.host.blank? || (! HOST_WHITELIST.include?(url.host))
+    return unless (url.scheme == 'http')
+    url
+  end
+end

--- a/examples/statsd_demo.rb
+++ b/examples/statsd_demo.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+# See notes in examples/test_rig for preconditions and usage
+
+require File.expand_path('test_rig', File.dirname(__FILE__))
+require 'goliath/contrib/statsd_agent'
+
+class StatsdDemo < TestRig
+  statsd_agent = Goliath::Contrib::StatsdAgent.new('statsd_demo', '33.33.33.30')
+  plugin Goliath::Contrib::Plugin::StatsdPlugin, statsd_agent
+  use    Goliath::Contrib::Rack::StatsdLogger,   statsd_agent
+  
+  self.set_middleware!
+
+end

--- a/examples/test_rig.rb
+++ b/examples/test_rig.rb
@@ -12,7 +12,16 @@ require 'goliath/contrib/rack/force_timeout'
 require 'goliath/contrib/rack/handle_exceptions'
 
 #
-# A test endpoint allowing fault injection, variable delay, or a response forced by the client.
+# A test endpoint allowing fault injection, variable delay, or a response forced
+# by the client.  Besides being a nice demo of those middlewares, it's a useful
+# test dummy for seeing how your SOA apps handle downstream failures.
+#
+# Launch with
+#
+#     bundle exec ./examples/test_rig.rb       -s -p 9000 -e development &
+#
+# If using it as a test rig, launch with `-e production`. The test rig acts on
+# the following URL parameters:
 #
 # * `_force_timeout`                    -- raise an error if response takes longer than given time
 # * `_force_delay`                      -- delay the given length of time before responding
@@ -20,27 +29,27 @@ require 'goliath/contrib/rack/handle_exceptions'
 # * `_force_fail`/`_force_fail_after`   -- raise an error of the given type (eg `_force_fail_pre=400` causes a BadRequestError)
 # * `_force_status`, `_force_headers`, or `_force_body' --  replace the given component directly.
 #
-# @example delay for 2 seconds
+# @example delay for 2 seconds:
 #   curl -v 'http://127.0.0.1:9000/?_force_delay=2'
-#   => {"_delay_ms":2.0,"_randelay_ms":0.0,"_actual_ms":2.006265640258789}
+#   => Headers: X-Resp-Delay: 2.0 / X-Resp-Randelay: 0.0 / X-Resp-Actual: 2.003681182861328
 #
-# @example drop connection
+# @example drop connection:
 #   curl -v 'http://127.0.0.1:9000/?_force_drop=true'
 #
-# @example delay for 2 seconds, then drop the connection
+# @example delay for 2 seconds, then drop the connection:
 #   curl -v 'http://127.0.0.1:9000/?_force_delay=2&_force_drop_after=true'
 #
-# @example force timeout: first call is 200 OK, second will error with 408 RequestTimeoutError
+# @example force timeout; first call is 200 OK, second will error with 408 RequestTimeoutError:
 #   curl -v 'http://127.0.0.1:9000/?_force_timeout=1.0&_force_delay=0.5'
-#   => {"_delay_ms":0.5,"_randelay_ms":0.0,"_actual_ms":0.53464674949646}
+#   => Headers: X-Resp-Delay: 0.5 / X-Resp-Randelay: 0.0 / X-Resp-Actual: 0.513401985168457 / X-Resp-Timeout: 1.0
 #   curl -v 'http://127.0.0.1:9000/?_force_timeout=1.0&_force_delay=2.0'
 #   => {"status":408,"error":"RequestTimeoutError","message":"Request exceeded 1.0 seconds"}
 #
-# @example simulate a 503
+# @example simulate a 503:
 #   curl -v 'http://127.0.0.1:9000/?_force_fault=503'
 #   => {"status":503,"error":"ServiceUnavailableError","message":"Injected middleware fault 503"}
 #
-# @example force-set headers and body
+# @example force-set headers and body:
 #   curl -v -H "Content-Type: application/json" --data-ascii '{"_force_headers":{"X-Question":"What is brown and sticky"},"_force_body":{"answer":"a stick"}}' 'http://127.0.0.1:9001/'
 #   => {"answer":"a stick"}
 #

--- a/examples/test_rig.rb
+++ b/examples/test_rig.rb
@@ -48,11 +48,12 @@ class TestRig < Goliath::API
   include Goliath::Contrib::CaptureHeaders
 
   def self.set_middleware!
+    use Goliath::Rack::Heartbeat                 # respond to /status with 200, OK (monitoring, etc)
     use Goliath::Rack::Tracer                    # log trace statistics
-    use Goliath::Rack::Params                    # parse & merge query and body parameters
     use Goliath::Rack::DefaultMimeType           # cleanup accepted media types
     use Goliath::Rack::Render, 'json'            # auto-negotiate response format
     use Goliath::Contrib::Rack::HandleExceptions # turn raised errors into HTTP responses
+    use Goliath::Rack::Params                    # parse & merge query and body parameters
 
     # turn params like '_force_delay' into env vars :force_delay
     use(Goliath::Contrib::Rack::ConfigurateFromParams,

--- a/examples/test_rig.rb
+++ b/examples/test_rig.rb
@@ -1,0 +1,53 @@
+#!/usr/bin/env ruby
+# $:.unshift File.expand_path('../lib', File.dirname(__FILE__))
+
+require 'goliath'
+require 'goliath/contrib/rack/diagnostics'
+require 'goliath/contrib/rack/force_delay'
+require 'goliath/contrib/rack/force_drop'
+require 'goliath/contrib/rack/force_fault'
+require 'goliath/contrib/rack/force_response'
+require 'goliath/contrib/rack/handle_exceptions'
+
+#
+# A test endpoint allowing fault injection, variable delay, or a response forced by the client.
+#
+# * with `_delay`               parameter, delay the given length of time before responding
+# * with `_drop`/`_drop_post`   parameter, drop connection with no response
+# * with `_fail`/`_fail_post`   parameter, raise an error of the given type (eg `_fail_pre=400` causes a BadRequestError)
+# * with `_status`, `_headers`, or `_body' parameter, replace the given component directly.
+#
+# @example set headers
+#   curl -v -H "Content-Type: application/json" --data-ascii '{"_headers":{"X-Question":"What is brown and sticky"},"_body":{"answer":"a stick"}}' 'http://127.0.0.1:9001/'
+#
+# @example drop connection
+#   curl -v 'http://127.0.0.1:9000/?_drop_pre=true'
+#
+# @example delay for 3 seconds
+#   curl -v 'http://127.0.0.1:9000/?_delay=2'
+#
+# @example delay for 3 seconds, then drop the connection (using drop_after)
+#   curl -v 'http://127.0.0.1:9000/?_delay=2&_drop_post=true'
+#
+class TestRig < Goliath::API
+  include Goliath::Contrib::CaptureHeaders
+
+  def self.set_middleware!
+    use Goliath::Rack::Tracer                    # log trace statistics
+    use Goliath::Rack::Params                    # parse & merge query and body parameters
+    use Goliath::Rack::DefaultMimeType           # cleanup accepted media types
+    use Goliath::Rack::Render, 'json'            # auto-negotiate response format
+
+    use Goliath::Contrib::Rack::HandleExceptions # turn raised errors into HTTP responses
+    use Goliath::Contrib::Rack::ForceDrop        # drop connection if 'drop' param
+    use Goliath::Contrib::Rack::ForceFault       # raise an error if 'fail' param
+    use Goliath::Contrib::Rack::ForceResponse    # replace with given value if '_status', '_headers' or '_body' is returned
+    use Goliath::Contrib::Rack::ForceDelay       # force response to take at least (_delay +/- _randelay) seconds
+    use Goliath::Contrib::Rack::Diagnostics      # summarize the request in the response headers
+  end
+  self.set_middleware!
+
+  def response(env)
+    [200, { 'X-API' => self.class.name }, {}]
+  end
+end

--- a/goliath-contrib.gemspec
+++ b/goliath-contrib.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'multipart_body'
   s.add_development_dependency 'amqp', '>=0.7.1'
   s.add_development_dependency 'em-websocket-client'
+  s.add_development_dependency 'postrank-uri'
 
   s.add_development_dependency 'tilt', '>=1.2.2'
   s.add_development_dependency 'haml', '>=3.0.25'

--- a/goliath-contrib.gemspec
+++ b/goliath-contrib.gemspec
@@ -18,21 +18,16 @@ Gem::Specification.new do |s|
   s.add_dependency 'goliath'
 
   s.add_development_dependency 'rspec', '>2.0'
-  s.add_development_dependency 'nokogiri'
-  s.add_development_dependency 'em-http-request', '>=1.0.0'
-  s.add_development_dependency 'em-mongo', '~> 0.4.0'
-  s.add_development_dependency 'rack-rewrite'
-  s.add_development_dependency 'multipart_body'
-  s.add_development_dependency 'amqp', '>=0.7.1'
-  s.add_development_dependency 'em-websocket-client'
-  s.add_development_dependency 'postrank-uri'
 
-  s.add_development_dependency 'tilt', '>=1.2.2'
-  s.add_development_dependency 'haml', '>=3.0.25'
-  s.add_development_dependency 'yard'
+  s.add_development_dependency 'em-http-request', '>=1.0.0'
+  s.add_development_dependency 'postrank-uri'
 
   s.add_development_dependency 'guard'
   s.add_development_dependency 'guard-rspec'
+  if RUBY_PLATFORM.include?('darwin')
+    s.add_development_dependency 'growl', '~> 1.0.3'
+    s.add_development_dependency 'rb-fsevent'
+  end
 
   if RUBY_PLATFORM != 'java'
     s.add_development_dependency 'yajl-ruby'
@@ -41,11 +36,6 @@ Gem::Specification.new do |s|
   else
     s.add_development_dependency 'json-jruby'
     s.add_development_dependency 'maruku'
-  end
-
-  if RUBY_PLATFORM.include?('darwin')
-    s.add_development_dependency 'growl', '~> 1.0.3'
-    s.add_development_dependency 'rb-fsevent'
   end
 
   ignores = File.readlines(".gitignore").grep(/\S+/).map {|i| i.chomp }

--- a/goliath-contrib.gemspec
+++ b/goliath-contrib.gemspec
@@ -1,23 +1,61 @@
 # -*- encoding: utf-8 -*-
+$:.push File.expand_path("../lib", __FILE__)
+require 'goliath/contrib/version'
 
-require File.expand_path('../lib/goliath/contrib', __FILE__)
+Gem::Specification.new do |s|
+  s.name        = "goliath-contrib"
+  s.version     = Goliath::Contrib::VERSION
 
-# require './lib/goliath/contrib'
+  s.authors     = ["goliath-io"]
+  s.email       = ["goliath-io@googlegroups.com"]
 
-Gem::Specification.new do |gem|
-  gem.authors       = ["goliath-io"]
-  gem.email         = ["goliath-io@googlegroups.com"]
+  s.homepage    = "https://github.com/postrank-labs/goliath-contrib"
+  s.summary     = "Contributed Goliath middleware, plugins, and utilities"
+  s.description = s.summary
 
-  gem.homepage      = "https://github.com/postrank-labs/goliath-contrib"
-  gem.description   = "Contributed Goliath middleware, plugins, and utilities"
-  gem.summary       = gem.description
+  s.required_ruby_version = '>=1.9.2'
 
-  gem.files         = `git ls-files`.split($\)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.name          = "goliath-contrib"
-  gem.require_paths = ["lib"]
-  gem.version       = Goliath::Contrib::VERSION
+  s.add_dependency 'goliath'
 
-  gem.add_dependency 'goliath'  
+  s.add_development_dependency 'rspec', '>2.0'
+  s.add_development_dependency 'nokogiri'
+  s.add_development_dependency 'em-http-request', '>=1.0.0'
+  s.add_development_dependency 'em-mongo', '~> 0.4.0'
+  s.add_development_dependency 'rack-rewrite'
+  s.add_development_dependency 'multipart_body'
+  s.add_development_dependency 'amqp', '>=0.7.1'
+  s.add_development_dependency 'em-websocket-client'
+
+  s.add_development_dependency 'tilt', '>=1.2.2'
+  s.add_development_dependency 'haml', '>=3.0.25'
+  s.add_development_dependency 'yard'
+
+  s.add_development_dependency 'guard'
+  s.add_development_dependency 'guard-rspec'
+
+  if RUBY_PLATFORM != 'java'
+    s.add_development_dependency 'yajl-ruby'
+    s.add_development_dependency 'bluecloth'
+    s.add_development_dependency 'bson_ext'
+  else
+    s.add_development_dependency 'json-jruby'
+    s.add_development_dependency 'maruku'
+  end
+
+  if RUBY_PLATFORM.include?('darwin')
+    s.add_development_dependency 'growl', '~> 1.0.3'
+    s.add_development_dependency 'rb-fsevent'
+  end
+
+  ignores = File.readlines(".gitignore").grep(/\S+/).map {|i| i.chomp }
+  dotfiles = [".gemtest", ".gitignore", ".rspec", ".yardopts"]
+
+  # s.files         = `git ls-files`.split($\)
+  # s.executables   = s.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  # s.test_files    = s.files.grep(%r{^(test|spec|features)/})
+  # s.require_paths = ["lib"]
+
+  s.files = Dir["**/*"].reject {|f| File.directory?(f) || ignores.any? {|i| File.fnmatch(i, f) } } + dotfiles
+  s.test_files = s.files.grep(/^spec\//)
+  s.require_paths = ['lib']
 end

--- a/lib/goliath/contrib.rb
+++ b/lib/goliath/contrib.rb
@@ -1,11 +1,9 @@
+require 'goliath/contrib'
+
 # TODO: tries to start server :-)
 # require 'goliath'
 
 module Goliath
-  module Contrib
-  	VERSION = "1.0.0.beta1"
-  end
-
   # autoload :MiddlewareName, "goliath/contrib/middleware_name"
   # ...
 end

--- a/lib/goliath/contrib/plugin/statsd_plugin.rb
+++ b/lib/goliath/contrib/plugin/statsd_plugin.rb
@@ -1,0 +1,63 @@
+module Goliath
+  module Contrib
+    module Plugin
+
+      # Initializes the statsd agent and dispatches regular metrics about this server
+      #
+      # Often enjoyed in the company of the Goliath::Contrib::Rack::StatsdLogger middleware.
+      #
+      # @example
+      #   plugin Goliath::Contrib::Plugin::StatsdPlugin, Goliath::Contrib::StatsdAgent.new('my_app', '33.33.33.30')
+      #
+      # A URL something like this will show you the state of the reactor latency:
+      #
+      #     http://33.33.33.30:5100/render/?from=-12minutes
+      #       &width=960&height=720
+      #       &yMin=&yMax=
+      #       &colorList=67A9CF,91CF60,1A9850,FC8D59,D73027
+      #       &bgcolor=FFFFF0
+      #       &fgcolor=808080
+      #       &target=stats.timers.statsd_demo.reactor.latency.lower
+      #       &target=stats.timers.statsd_demo.reactor.latency.mean_90
+      #       &target=stats.timers.statsd_demo.reactor.latency.upper_90
+      #       &target=stats.timers.statsd_demo.reactor.latency.upper
+      #
+      class StatsdPlugin
+        attr_reader :agent
+
+        # Called by the framework to initialize the plugin
+        #
+        # @param port [Integer] Unused
+        # @param global_config [Hash] The server configuration data
+        # @param status [Hash] A status hash
+        # @param logger [Log4R::Logger] The logger
+        # @return [Goliath::Contrib::Plugins::StatsdPlugin] An instance of the Goliath::Contrib::Plugins::StatsdPlugin plugin
+        def initialize(port, global_config, status, logger)
+          @logger = logger
+          @config = global_config
+        end
+
+        # Called automatically to start the plugin
+        #
+        # @example
+        #   plugin Goliath::Contrib::Plugin::StatsdPlugin, Goliath::Contrib::StatsdAgent.new('my_app')
+        def run(agent)
+          @agent = agent
+          agent.logger ||= @logger
+          register_latency_timer
+        end
+
+        # Send canary packets to the statsd reporting on this server's latency every 1 second
+        def register_latency_timer
+          @logger.info{ "#{self.class} registering timer for reactor latency" }
+          @last   = Time.now.to_f
+          #
+          EM.add_periodic_timer(1.0) do
+            agent.timing 'reactor.latency', (Time.now.to_f - @last)
+            @last = Time.now.to_f
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/goliath/contrib/rack/batch_iterator.rb
+++ b/lib/goliath/contrib/rack/batch_iterator.rb
@@ -1,0 +1,190 @@
+class BatchIterator < EM::Synchrony::Iterator
+  include Goliath::Rack::Validator
+
+  DEFAULT_CONCURRENCY = 10 unless defined?(DEFAULT_CONCURRENCY)
+
+  def initialize(env, batch_id, timeout, queries, concurrency=nil)
+    concurrency ||= DEFAULT_CONCURRENCY
+    @env          = env
+    @batch_id     = batch_id
+    @http_options = Hash.new
+    @http_options[:inactivity_timeout] = timeout.to_s
+    @http_options[:connect_timeout   ] = timeout.to_s
+    #
+    @results = {}
+    @errors  = {}
+    super queries, concurrency
+  end
+
+  def perform
+    EM.synchrony do
+      # first part of response
+      EM.next_tick{ safely(@env){ response_preamble } }
+
+      # rest of response
+      each(
+        proc{|(req_id, url), iter| safely(@env){
+            p [url, @http_options]
+            req = EM::HttpRequest.new(url, @http_options).aget
+            req.callback{ safely(@env){ handle_result(req_id, req) ; iter.next } }
+            req.errback{  safely(@env){ handle_error( req_id, req) ; iter.next } }
+            @env.logger.debug [object_id, "request", req_id, req.req.uri.query].join("\t")
+        } },
+        # called at finish
+        proc{ safely(@env){
+          send_response_coda
+          @env.chunked_stream_close
+        } }
+        )
+    end
+  end
+
+protected
+
+  # Called once before iterator starts, but after stream has initialized.
+  # Use this for any initial portion of the payload
+  def response_preamble
+  end
+
+  # Called on successful response -- saves the result.
+  #
+  # This method is called if our *HttpRequest* succeeded -- even if it's a 404
+  # or 503 or whatever back from the client, that's a successful response
+  #
+  # @param [String]      req_id The arbitrary id for this request, chosen by the caller
+  # @param [HttpRequest] req    The successful HttpRequest connection object
+  #
+  def handle_result req_id, req
+    @results[req_id] = [
+      req.response_header.http_status,
+      req.response_header,
+      req.response.to_s.chomp
+    ]
+  end
+
+  # Called on each unsuccessful response -- save a summary of the error
+  #
+  # @param [String]      req_id The arbitrary id for this request, chosen by the caller
+  # @param [HttpRequest] req    The unsuccessful HttpRequest connection object
+  #
+  # This method is called if our *HttpRequest* succeeded -- even if it's a 404
+  # or 503 or whatever back from the client, that's a successful response, and
+  # this method is not called.
+  #
+  # The error messages for HttpRequest are often (always?) blank -- a bug is
+  # pending to fix this.
+  def handle_error req_id, req
+    err = req.error.to_s
+    err = 'no_response' if err.empty?
+    @errors[req_id]  = [Goliath::Validation::BadRequestError.status_code, {}, err]
+  end
+
+  #
+  # A helpful hash of statistics about the batch
+  #
+  def stats
+    {
+      :duration           => (Time.now.to_f - @env[:start_time]).round(3),
+      :queries            => (@results.length + @errors.length),
+      :concurrency        => concurrency,
+      :inactivity_timeout => @http_options[:inactivity_timeout],
+      :connect_timeout    => @http_options[:connect_timeout],
+      :batch_id           => @batch_id,
+    }
+  end
+
+  # Called after all responses have completed, before the stream is closed.
+  def send_response_coda
+  end
+end
+
+#
+# Makes a JSON response in batches. The preamble opens a hash with field
+# "results". Each successful response is delivered in a single line, as a single
+# chunked-transfer chunk, mapping the req_id (as a json string) to a hash with
+# the response http status code and the JSON-encoded body. NOTE: the body is
+# JSON-encoded from whatever it was! If it was already JSON, you will need to
+# call JSON.parse again on the body.
+#
+# Errors are accumulated as they roll in. After all requests complete, this
+# dumps out a row with helpful stats, and the hash of errback results.
+#
+#     {
+#     "results":{
+#     "13348":{"status":200,"body":"{\"trstrank\":4.9,\"user_id\":13348,\"screen_name\":\"Scobleizer\",\"tq\":99}"},
+#     "18686296":{"status":200,"body":"{\"trstrank\":0.65,\"user_id\":18686296,\"screen_name\":\"bryanconnor\",\"tq\":99}"},
+#     "_count":2},
+#     "stats":{"duration":3.593,"queries":100,"concurrency":15,"inactivity_timeout":2.0,"connect_timeout":1.0},
+#     "errors":{"1554031":{"error":"no_response"}}
+#     }
+#
+#
+class JsonBatchIterator < BatchIterator
+  # Begin text for a hash with field "results".
+  def response_preamble
+    super
+    send "{"
+    send '"results":{'
+  end
+
+  # Deliver successful response -- sends a single line (as a single
+  # chunked-transfer chunk) mapping the request ID to a hash holding the http
+  # status code and the JSON-encoded body.
+  #
+  # NOTE: the body is JSON-encoded, whatever it was! If it was already JSON,
+  # you will need to call JSON.parse again on the body.
+  def handle_result(req_id, req)
+    status, headers, body = super
+    send_key  = MultiJson.dump(req_id)
+    send_body = MultiJson.dump(status: status, body: body)
+    send send_key, ":", send_body, ','
+  end
+
+  # Unsuccessful responses are delivered in the response_coda, so we don't need
+  # to do anything but let `super` record the response
+  def handle_error req_id, req
+    super
+  end
+
+  # Dumps a row with helpful stats and the hash of errback results.
+  def send_response_coda
+    super
+    send '"_":{}},' # end results hash
+    send '"stats":',  MultiJson.dump(stats), ','
+    send '"errors":', MultiJson.dump(@errors)
+    send '}'
+  end
+
+  def send *parts
+    @env.chunked_stream_send("#{parts.join}\n")
+  end
+end
+
+# outputs results, one per line, tab-separated. Each line is
+#
+#     EVENT     req_id    status   body\n
+#
+# No changes are made to the body except to scrub it for internal CR, LF and TAB
+#
+class TsvBatchIterator < BatchIterator
+  def handle_result req_id, req
+    status, headers, body = super
+    send_tsv '_r', req_id, status, body
+  end
+
+  def handle_error req_id, req
+    status, headers, body = super
+    send_tsv '_e', req_id, status, body
+  end
+
+  def send_response_coda
+    super
+    send_tsv '_s',  '', '', stats.values.join("\t")
+  end
+
+  def send_tsv(event, req_id, status, body)
+    body = body.to_s.gsub(/[\r\n]+/, " ")
+    line = [event, req_id, status, body].join("\t")
+    @env.chunked_stream_send("#{line}\n")
+  end
+end

--- a/lib/goliath/contrib/rack/configurator.rb
+++ b/lib/goliath/contrib/rack/configurator.rb
@@ -1,0 +1,48 @@
+module Goliath
+  module Contrib
+    module Rack
+
+      # Place static values fron initialize into the env on each request
+      class StaticConfigurator
+        include Goliath::Rack::AsyncMiddleware
+
+        def initialize(app, env_vars)
+          @extra_env_vars = env_vars
+          super(app)
+        end
+
+        def call(env,*)
+          env.merge!(@extra_env_vars)
+          super
+        end
+      end
+
+      #
+      #
+      # @example imposes a timeout if 'rapid_timeout' param is present
+      #   class RapidServiceOrYour408Back < Goliath::API
+      #     use Goliath::Rack::Params
+      #     use ConfigurateFromParams, [:timeout], 'rapid'
+      #     use Goliath::Contrib::Rack::ForceTimeout
+      #   end
+      #
+      class ConfigurateFromParams
+        include Goliath::Rack::AsyncMiddleware
+
+        def initialize(app, param_keys, slug='')
+          @extra_env_vars = param_keys.inject({}){|acc,el| acc[el.to_sym] = [slug, el].join("_") ; acc }
+          super(app)
+        end
+
+        def call(env,*)
+          @extra_env_vars.each do |env_key, param_key|
+            # env.logger.info [env_key, param_key, env.params[param_key]]
+            env[env_key] ||= env.params.delete(param_key)
+          end
+          super
+        end
+      end
+
+    end
+  end
+end

--- a/lib/goliath/contrib/rack/cors_access_control.rb
+++ b/lib/goliath/contrib/rack/cors_access_control.rb
@@ -1,0 +1,60 @@
+# Settings.define :acc, :default => nil
+
+module Goliath
+  module Contrib
+    module Rack
+
+      #
+      # Provides Cross-Origin Resource Sharing headers, a superior alternative to
+      # JSON-p responses.
+      #
+      # This implementation is **entirely promiscuous**: it says "yep, that is
+      # allowed" to _any_ request. The more circumspect user should investigate
+      # https://github.com/cyu/rack-cors/
+      #
+      # @example
+      #   # A request with method OPTIONS and Access-Control-Request-Headers set
+      #   # to 'Content-Type,X-Zibit' would receive headers
+      #   {
+      #     'Access-Control-Allow-Origin'   => '*',
+      #     'Access-Control-Allow-Methods'  => 'POST, GET, OPTIONS',
+      #     'Access-Control-Max-Age'        => '172800',
+      #     'Access-Control-Expose-Headers' => 'X-Error-Message,X-Error-Detail,X-RateLimit-Requests,X-RateLimit-MaxRequests',
+      #     'Access-Control-Allow-Headers'  => 'Content-Type,X-Zibit'
+      #   }
+      #
+      #
+      class CorsAccessControl
+        include Goliath::Rack::AsyncMiddleware
+
+        DEFAULT_CORS_HEADERS = {
+          'Access-Control-Allow-Origin'   => '*',
+          'Access-Control-Expose-Headers' => 'X-Error-Message,X-Error-Detail,X-RateLimit-Requests,X-RateLimit-MaxRequests',
+          'Access-Control-Max-Age'        => '172800',
+          'Access-Control-Allow-Methods'  => 'POST, GET, OPTIONS',
+          'Access-Control-Allow-Headers'  => 'X-Requested-With,Content-Type'
+        }
+
+        def access_control_headers(env)
+          cors_headers = DEFAULT_CORS_HEADERS.dup
+          client_headers_to_approve = env['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'].to_s.gsub(/[^\w\-\,]+/,'')
+          cors_headers['Access-Control-Allow-Headers'] += ",#{client_headers_to_approve}" if not client_headers_to_approve.empty?
+          cors_headers
+        end
+
+        def call(env, *args)
+          if env[Goliath::Request::REQUEST_METHOD] == 'OPTIONS'
+            return [200, access_control_headers(env), []]
+          end
+          super(env)
+        end
+
+        def post_process(env, status, headers, body)
+          headers['Access-Control-Allow-Origin'] = '*'
+          [status, headers, body]
+        end
+      end
+
+    end
+  end
+end

--- a/lib/goliath/contrib/rack/cors_access_control.rb
+++ b/lib/goliath/contrib/rack/cors_access_control.rb
@@ -20,7 +20,7 @@ module Goliath
       #     'Access-Control-Allow-Methods'  => 'POST, GET, OPTIONS',
       #     'Access-Control-Max-Age'        => '172800',
       #     'Access-Control-Expose-Headers' => 'X-Error-Message,X-Error-Detail,X-RateLimit-Requests,X-RateLimit-MaxRequests',
-      #     'Access-Control-Allow-Headers'  => 'Content-Type,X-Zibit'
+      #     'Access-Control-Allow-Headers'  => 'X-Requested-With,Content-Type,X-Zibit'
       #   }
       #
       #

--- a/lib/goliath/contrib/rack/diagnostics.rb
+++ b/lib/goliath/contrib/rack/diagnostics.rb
@@ -1,0 +1,46 @@
+module Goliath
+  module Contrib
+
+    module CaptureHeaders
+      # save client headers (only) into env[:client_headers]
+      def on_headers(env, headers)
+        env[:client_headers] = headers
+        super(env, headers) if defined?(super)
+      end
+    end
+
+    module Rack
+
+      #
+      # Add headers showing the request's parameters, path, headers and method
+      #
+      # You must also include Goliath::Contrib::CaptureHeaders in your responder class
+      #
+      # @example
+      #   class AwesomeService < Goliath::API
+      #     include Goliath::Contrib::CaptureHeaders
+      #     use     Goliath::Contrib::Rack::Diagnostics
+      class Diagnostics
+        include Goliath::Rack::AsyncMiddleware
+
+        def request_diagnostics(env)
+          client_headers = env[:client_headers] or env.logger.info("Please 'include Goliath::Contrib::CaptureHeaders' in your API class")
+          req_params  = env.params.collect{|param|     param.join(": ") }
+          req_headers = client_headers.collect{|param| param.join(": ") }
+          {
+            "X-Next"        => @app.class.name,
+            "X-Req-Params"  => req_params.join("|"),
+            "X-Req-Path"    => env[Goliath::Request::REQUEST_PATH],
+            "X-Req-Headers" => req_headers.join("|"),
+            "X-Req-Method"  => env[Goliath::Request::REQUEST_METHOD]}
+        end
+
+        def post_process env, status, headers, body
+          headers.merge!(request_diagnostics(env))
+          [status, headers, body]
+        end
+      end
+
+    end
+  end
+end

--- a/lib/goliath/contrib/rack/diagnostics.rb
+++ b/lib/goliath/contrib/rack/diagnostics.rb
@@ -44,7 +44,7 @@ module Goliath
             "X-Req-Params"  => req_params.join("|"),
             "X-Req-Path"    => env[Goliath::Request::REQUEST_PATH],
             "X-Req-Headers" => req_headers.join("|"),
-            "X-Req-Method"  => env[Goliath::Request::REQUEST_METHOD]}
+            "X-Req-Method"  => env[Goliath::Request::REQUEST_METHOD] }
         end
 
         def post_process env, status, headers, body

--- a/lib/goliath/contrib/rack/diagnostics.rb
+++ b/lib/goliath/contrib/rack/diagnostics.rb
@@ -1,6 +1,16 @@
 module Goliath
   module Contrib
 
+    # saves client headers into env[:client_headers]
+    #
+    # This is a module, not middleware: apps should `include` (not `use`) it.
+    # Also, please call 'super' if your app implements `on_headers`.
+    #
+    # @example
+    #   class AwesomeApp < Goliath::API
+    #     include Goliath::Contrib::CaptureHeaders
+    #   end
+    #
     module CaptureHeaders
       # save client headers (only) into env[:client_headers]
       def on_headers(env, headers)
@@ -14,19 +24,21 @@ module Goliath
       #
       # Add headers showing the request's parameters, path, headers and method
       #
-      # You must also include Goliath::Contrib::CaptureHeaders in your responder class
+      # Please also include Goliath::Contrib::CaptureHeaders in your app class.
       #
       # @example
-      #   class AwesomeService < Goliath::API
+      #   class AwesomeApp < Goliath::API
       #     include Goliath::Contrib::CaptureHeaders
       #     use     Goliath::Contrib::Rack::Diagnostics
+      #   end
+      #
       class Diagnostics
         include Goliath::Rack::AsyncMiddleware
 
         def request_diagnostics(env)
           client_headers = env[:client_headers] or env.logger.info("Please 'include Goliath::Contrib::CaptureHeaders' in your API class")
           req_params  = env.params.collect{|param|     param.join(": ") }
-          req_headers = client_headers.collect{|param| param.join(": ") }
+          req_headers = (client_headers||{}).collect{|param| param.join(": ") }
           {
             "X-Next"        => @app.class.name,
             "X-Req-Params"  => req_params.join("|"),

--- a/lib/goliath/contrib/rack/force_delay.rb
+++ b/lib/goliath/contrib/rack/force_delay.rb
@@ -3,18 +3,25 @@ module Goliath
 
     module Rack
 
-      # Delays response for `_delay + (0 to _randelay)` seconds, as given by the
-      # `_delay` and `_randelay` request parameters. Delays longer than 5
-      # seconds are clamped to 5 seconds.
+      # Delays response for `delay + (0 to randelay)` additional seconds after
+      # the app's response.
       #
       # This delay is non-blocking -- *other* requests may proceed in turn --
       # though naturally the call chain for this response doesn't proceed until
       # the delay is complete.
       #
-      # Information about the delay is added to the response headers for your enjoyment.
+      # ForceDelay ensures your response takes *at least* N seconds. Force
+      # Timeout ensures your response takes *at most* N seconds. To have a
+      # response take *as-close-as-reasonable-to* N seconds, use an N-second
+      # ForceTimeout with an (N+1)-second ForceDelay.
       #
-      # @example simulate a highly variable response time (min 0.5, max 1.5 seconds)
-      #   curl -v 'http://127.0.0.1:9000/?_delay=0.5&_randelay=1.0'
+      # The `force_delay` and `force_randelay` env variables specify the delay;
+      # values are clamped to be less than 5 seconds. Information about the
+      # delay is added to the response headers for your enjoyment.
+      #
+      # @example simulate a highly variable (0.5-1.5 sec) response time (see examples/test_rig.rb):
+      #   curl -v 'http://127.0.0.1:9000/?_force_delay=0.5&_force_randelay=1.0'
+      #   => Headers: X-Resp-Delay: 0.5 / X-Resp-Randelay: 1.0 / X-Resp-Actual: 0.90205979347229
       #
       class ForceDelay
         include Goliath::Rack::AsyncMiddleware
@@ -27,7 +34,6 @@ module Goliath
             be_sleepy(delay, randelay)
             actual = (Time.now.to_f - env[:start_time])
             headers.merge!( 'X-Resp-Delay' => delay.to_s, 'X-Resp-Randelay' => randelay.to_s, 'X-Resp-Actual' => actual.to_s )
-            body.merge!( :_delay_ms => delay, :_randelay_ms => randelay, :_actual_ms => actual, :_delay_start => env[:start_time].to_f )
           end
           [status, headers, body]
         end

--- a/lib/goliath/contrib/rack/force_delay.rb
+++ b/lib/goliath/contrib/rack/force_delay.rb
@@ -20,14 +20,14 @@ module Goliath
         include Goliath::Rack::AsyncMiddleware
 
         def post_process(env, status, headers, body)
-          delay    = env.params['_delay'].to_f
-          randelay = env.params['_randelay'].to_f
+          delay    = env[:force_delay].to_f
+          randelay = env[:force_randelay].to_f
           #
           if (delay > 0) || (randelay > 0)
             be_sleepy(delay, randelay)
             actual = (Time.now.to_f - env[:start_time])
             headers.merge!( 'X-Resp-Delay' => delay.to_s, 'X-Resp-Randelay' => randelay.to_s, 'X-Resp-Actual' => actual.to_s )
-            body.merge!( :_delay_ms => delay, :randelay_ms => randelay, :_actual_ms => actual )
+            body.merge!( :_delay_ms => delay, :_randelay_ms => randelay, :_actual_ms => actual )
           end
           [status, headers, body]
         end

--- a/lib/goliath/contrib/rack/force_delay.rb
+++ b/lib/goliath/contrib/rack/force_delay.rb
@@ -1,0 +1,45 @@
+module Goliath
+  module Contrib
+
+    module Rack
+
+      # Delays response for `_delay + (0 to _randelay)` seconds, as given by the
+      # `_delay` and `_randelay` request parameters. Delays longer than 5
+      # seconds are clamped to 5 seconds.
+      #
+      # This delay is non-blocking -- *other* requests may proceed in turn --
+      # though naturally the call chain for this response doesn't proceed until
+      # the delay is complete.
+      #
+      # Information about the delay is added to the response headers for your enjoyment.
+      #
+      # @example simulate a highly variable response time (min 0.5, max 1.5 seconds)
+      #   curl -v 'http://127.0.0.1:9000/?_delay=0.5&_randelay=1.0'
+      #
+      class ForceDelay
+        include Goliath::Rack::AsyncMiddleware
+
+        def post_process(env, status, headers, body)
+          delay    = env.params['_delay'].to_f
+          randelay = env.params['_randelay'].to_f
+          #
+          if (delay > 0) || (randelay > 0)
+            be_sleepy(delay, randelay)
+            actual = (Time.now.to_f - env[:start_time])
+            headers.merge!( 'X-Resp-Delay' => delay.to_s, 'X-Resp-Randelay' => randelay.to_s, 'X-Resp-Actual' => actual.to_s )
+            body.merge!( :_delay_ms => delay, :randelay_ms => randelay, :_actual_ms => actual )
+          end
+          [status, headers, body]
+        end
+
+        # sleep time limited to 5 seconds
+        def be_sleepy(delay, randelay)
+          total  = delay + (randelay * rand)
+          total  = [0, [total, 5].min].max # clamp
+          #
+          EM::Synchrony.sleep(total)
+        end
+      end
+    end
+  end
+end

--- a/lib/goliath/contrib/rack/force_delay.rb
+++ b/lib/goliath/contrib/rack/force_delay.rb
@@ -27,7 +27,7 @@ module Goliath
             be_sleepy(delay, randelay)
             actual = (Time.now.to_f - env[:start_time])
             headers.merge!( 'X-Resp-Delay' => delay.to_s, 'X-Resp-Randelay' => randelay.to_s, 'X-Resp-Actual' => actual.to_s )
-            body.merge!( :_delay_ms => delay, :_randelay_ms => randelay, :_actual_ms => actual )
+            body.merge!( :_delay_ms => delay, :_randelay_ms => randelay, :_actual_ms => actual, :_delay_start => env[:start_time].to_f )
           end
           [status, headers, body]
         end

--- a/lib/goliath/contrib/rack/force_drop.rb
+++ b/lib/goliath/contrib/rack/force_drop.rb
@@ -1,0 +1,38 @@
+module Goliath
+  module Contrib
+    module Rack
+
+      # Middleware to simulate dropping a connection.
+      #
+      # * if the _drop      parameter is given, close the connection as soon as possible
+      # * if the _drop_post parameter is given, close the connection late (after all following middlewares have happened)
+      #
+      # @example drop the connection immediately
+      #   curl 'http://localhost:9000/?_drop=true'
+      #
+      # @example wait one second then drop the connection with no response. Note that you must use `_drop_post`
+      #   curl 'http://localhost:9000/?_drop_post=true&_delay=1'
+      #
+      class ForceDrop
+        include Goliath::Rack::AsyncMiddleware
+
+        def call(env)
+          return super unless env.params['_drop'].to_s == 'true'
+
+          env.logger.info "Forcing dropped connection"
+          env.stream_close
+          [0, {}, {}]
+        end
+
+        def post_process(env, status, headers, body)
+          return super unless env.params['_drop_post'].to_s == 'true'
+
+          env.logger.info "Forcing dropped connection (after having run through other warez)"
+          env.stream_close
+          [0, {}, {}]
+        end
+
+      end
+    end
+  end
+end

--- a/lib/goliath/contrib/rack/force_drop.rb
+++ b/lib/goliath/contrib/rack/force_drop.rb
@@ -4,20 +4,20 @@ module Goliath
 
       # Middleware to simulate dropping a connection.
       #
-      # * if the _drop      parameter is given, close the connection as soon as possible
-      # * if the _drop_post parameter is given, close the connection late (after all following middlewares have happened)
+      # * if the _drop       env var is given, close the connection as soon as possible
+      # * if the _drop_after env var is given, close the connection late (after all following middlewares have happened)
       #
       # @example drop the connection immediately
       #   curl 'http://localhost:9000/?_drop=true'
       #
-      # @example wait one second then drop the connection with no response. Note that you must use `_drop_post`
-      #   curl 'http://localhost:9000/?_drop_post=true&_delay=1'
+      # @example wait one second then drop the connection with no response (note: `_drop_after`, not `_drop`)
+      #   curl 'http://localhost:9000/?_drop_after=true&_delay=1'
       #
       class ForceDrop
         include Goliath::Rack::AsyncMiddleware
 
         def call(env)
-          return super unless env.params['_drop'].to_s == 'true'
+          return super unless env[:force_drop].to_s == 'true'
 
           env.logger.info "Forcing dropped connection"
           env.stream_close
@@ -25,7 +25,7 @@ module Goliath
         end
 
         def post_process(env, status, headers, body)
-          return super unless env.params['_drop_post'].to_s == 'true'
+          return super unless env[:force_drop_after].to_s == 'true'
 
           env.logger.info "Forcing dropped connection (after having run through other warez)"
           env.stream_close

--- a/lib/goliath/contrib/rack/force_drop.rb
+++ b/lib/goliath/contrib/rack/force_drop.rb
@@ -4,14 +4,18 @@ module Goliath
 
       # Middleware to simulate dropping a connection.
       #
-      # * if the _drop       env var is given, close the connection as soon as possible
-      # * if the _drop_after env var is given, close the connection late (after all following middlewares have happened)
+      # * if the force_drop       env var is given, close the connection as soon as possible
+      # * if the force_drop_after env var is given, close the connection late (after all following middlewares have happened)
       #
-      # @example drop the connection immediately
-      #   curl 'http://localhost:9000/?_drop=true'
+      # @example drop the connection immediately (see examples/test_rig.rb):
+      #   time curl 'http://localhost:9000/?_force_drop=true'
+      #   => curl: (52) Empty reply from server
+      #   real  0m0.027s        user    0m0.008s        sys     0m0.005s
       #
-      # @example wait one second then drop the connection with no response (note: `_drop_after`, not `_drop`)
-      #   curl 'http://localhost:9000/?_drop_after=true&_delay=1'
+      # @example drop the connection with no response after waiting one second; the delay is provided by the `ForceDelay` middleware in `_drop_after` mode:
+      #   time curl 'http://localhost:9000/?_drop_after=true&_delay=1'
+      #   => curl: (52) Empty reply from server
+      #   real  0m1.111s        user    0m0.008s        sys     0m0.005s
       #
       class ForceDrop
         include Goliath::Rack::AsyncMiddleware

--- a/lib/goliath/contrib/rack/force_fault.rb
+++ b/lib/goliath/contrib/rack/force_fault.rb
@@ -1,12 +1,18 @@
 module Goliath
 
   module Validation ; class InjectedError < Error ; end ; end
-  
+
   module Contrib
     module Rack
 
-      # if either the '_fail_pre' or '_fail_after' parameter is given, raise an error
-      # The parameter's value (as an integer) becomes the response code
+      # if either the 'force_fault' or 'force_fault_after' env attribute are
+      # given, raise an error. The attribute's value (as an integer) becomes the
+      # response code.
+      #
+      # @example simulate a 503 (see `examples/test_rig.rb`):
+      #   curl -v 'http://127.0.0.1:9000/?_force_fault=503'
+      #   => {"status":503,"error":"ServiceUnavailableError","message":"Injected middleware fault 503"}
+      #
       class ForceFault
         include Goliath::Rack::AsyncMiddleware
 

--- a/lib/goliath/contrib/rack/force_fault.rb
+++ b/lib/goliath/contrib/rack/force_fault.rb
@@ -5,21 +5,21 @@ module Goliath
   module Contrib
     module Rack
 
-      # if either the '_fail_pre' or '_fail_post' parameter is given, raise an error
+      # if either the '_fail_pre' or '_fail_after' parameter is given, raise an error
       # The parameter's value (as an integer) becomes the response code
       class ForceFault
         include Goliath::Rack::AsyncMiddleware
 
         def call(env)
-          if code = env.params['_fault']
-            raise Goliath::Validation::InjectedError.new(code.to_i, "Injected middleware fault #{code}")
+          if fault_code = env[:force_fault]
+            raise Goliath::Validation::InjectedError.new(fault_code.to_i, "Injected middleware fault #{fault_code}")
           end
           super
         end
 
         def post_process(env, *)
-          if code = env.params['_fault_post']
-            raise Goliath::Validation::InjectedError.new(code.to_i, "Injected middleware fault #{code} (after response was composed)")
+          if fault_code = env[:force_fault_after]
+            raise Goliath::Validation::InjectedError.new(fault_code.to_i, "Injected middleware fault #{fault_code} (after response was composed)")
           end
           super
         end

--- a/lib/goliath/contrib/rack/force_fault.rb
+++ b/lib/goliath/contrib/rack/force_fault.rb
@@ -1,0 +1,31 @@
+module Goliath
+
+  module Validation ; class InjectedError < Error ; end ; end
+  
+  module Contrib
+    module Rack
+
+      # if either the '_fail_pre' or '_fail_post' parameter is given, raise an error
+      # The parameter's value (as an integer) becomes the response code
+      class ForceFault
+        include Goliath::Rack::AsyncMiddleware
+
+        def call(env)
+          if code = env.params['_fault']
+            raise Goliath::Validation::InjectedError.new(code.to_i, "Injected middleware fault #{code}")
+          end
+          super
+        end
+
+        def post_process(env, *)
+          if code = env.params['_fault_post']
+            raise Goliath::Validation::InjectedError.new(code.to_i, "Injected middleware fault #{code} (after response was composed)")
+          end
+          super
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/goliath/contrib/rack/force_response.rb
+++ b/lib/goliath/contrib/rack/force_response.rb
@@ -2,16 +2,15 @@ module Goliath
   module Contrib
     module Rack
 
-      # if _status, _headers or _body are given, blindly substitute their
-      # value, clobbering whatever was there.
-      #
-      # If you are going to use _headers you probably need to use a JSON post body.
+      # if force_status, force_headers or force_body env attributes are present,
+      # blindly substitute the attribute's value, clobbering whatever was there.
       #
       # @example setting headers with a JSON post body
-      #   curl -v -H "Content-Type: application/json" --data-ascii '{"_headers":{"X-Question":"What is brown and sticky"},"_body":{"answer":"a stick"}}' 'http://127.0.0.1:9001/'
+      #   curl -v -H "Content-Type: application/json" --data-ascii '{"_force_headers":{"X-Question":"What is brown and sticky"},"_force_body":{"answer":"a stick"}}' 'http://127.0.0.1:9001/'
+      #   => {"answer":"a stick"}
       #
-      # @example forcing a boring response body so ab doesn't whine about a varying response body size
-      #   ab -n 10000 -c 100  'http://localhost:9000/?_delay=0.4&_randelay=0.01&_body=OK'
+      # @example force a boring response body so ab doesn't whine about a varying response body size:
+      #   ab -n 10000 -c 100  'http://localhost:9000/?_force_body=OK'
       #
       class ForceResponse
         include Goliath::Rack::AsyncMiddleware

--- a/lib/goliath/contrib/rack/force_response.rb
+++ b/lib/goliath/contrib/rack/force_response.rb
@@ -17,9 +17,9 @@ module Goliath
         include Goliath::Rack::AsyncMiddleware
 
         def post_process(env, status, headers, body)
-          if (force_status  = env.params['_status'])  then  status  = force_status.to_i ; end
-          if (force_headers = env.params['_headers']) then  headers = force_headers     ; end
-          if (force_body    = env.params['_body'])    then  body    = force_body        ; end
+          if (force_status  = env[:force_status])  then  status  = force_status.to_i ; end
+          if (force_headers = env[:force_headers]) then  headers = force_headers     ; end
+          if (force_body    = env[:force_body])    then  body    = force_body        ; end
           [status, headers, body]
         end
 

--- a/lib/goliath/contrib/rack/force_response.rb
+++ b/lib/goliath/contrib/rack/force_response.rb
@@ -1,0 +1,29 @@
+module Goliath
+  module Contrib
+    module Rack
+
+      # if _status, _headers or _body are given, blindly substitute their
+      # value, clobbering whatever was there.
+      #
+      # If you are going to use _headers you probably need to use a JSON post body.
+      #
+      # @example setting headers with a JSON post body
+      #   curl -v -H "Content-Type: application/json" --data-ascii '{"_headers":{"X-Question":"What is brown and sticky"},"_body":{"answer":"a stick"}}' 'http://127.0.0.1:9001/'
+      #
+      # @example forcing a boring response body so ab doesn't whine about a varying response body size
+      #   ab -n 10000 -c 100  'http://localhost:9000/?_delay=0.4&_randelay=0.01&_body=OK'
+      #
+      class ForceResponse
+        include Goliath::Rack::AsyncMiddleware
+
+        def post_process(env, status, headers, body)
+          if (force_status  = env.params['_status'])  then  status  = force_status.to_i ; end
+          if (force_headers = env.params['_headers']) then  headers = force_headers     ; end
+          if (force_body    = env.params['_body'])    then  body    = force_body        ; end
+          [status, headers, body]
+        end
+
+      end
+    end
+  end
+end

--- a/lib/goliath/contrib/rack/force_timeout.rb
+++ b/lib/goliath/contrib/rack/force_timeout.rb
@@ -5,6 +5,18 @@ module Goliath
       #
       # Force a timeout after given number of seconds
       #
+      # ForceTimeout ensures your response takes *at most* N seconds. ForceDelay
+      # ensures your response takes *at least* N seconds. To have a response
+      # take *as-close-as-reasonable-to* N seconds, use an N-second ForceTimeout
+      # with an (N+1)-second ForceDelay.
+      #
+      #
+      # @example first call is 200 OK, second will error with 408 RequestTimeoutError (see examples/test_rig.rb):
+      #   curl -v 'http://127.0.0.1:9000/?_force_timeout=1.0&_force_delay=0.5'
+      #   => Headers: X-Resp-Delay: 0.5 / X-Resp-Randelay: 0.0 / X-Resp-Actual: 0.513401985168457 / X-Resp-Timeout: 1.0
+      #   curl -v 'http://127.0.0.1:9000/?_force_timeout=1.0&_force_delay=2.0'
+      #   => {"status":408,"error":"RequestTimeoutError","message":"Request exceeded 1.0 seconds"}
+      #
       class ForceTimeout
         include Goliath::Rack::Validator
 
@@ -28,6 +40,7 @@ module Goliath
             env['async.callback'] = Proc.new do |status, headers, body|
               unless env[:force_timeout_complete]
                 env[:force_timeout_complete] = true
+                headers.merge!('X-Resp-Timeout' => timeout.to_s)
                 async_cb.call([status, headers, body])
               end
             end
@@ -36,7 +49,11 @@ module Goliath
             # This will always fire, we just don't do anything if already handled.
             # If not handled elsewhere, mark as handled and raise an error
             EM.add_timer(timeout) do
-              async_cb.call(safely(env){ handle_timeout(env, timeout) })
+              unless env[:force_timeout_complete]
+                env[:force_timeout_complete] = true
+                err = Goliath::Validation::RequestTimeoutError.new("Request exceeded #{timeout} seconds")
+                async_cb.call(error_response(err, 'X-Resp-Timeout' => timeout.to_s))
+              end
             end
           end
 
@@ -48,12 +65,6 @@ module Goliath
           [status, headers, body]
         end
 
-        def handle_timeout(env, timeout)
-          unless env[:force_timeout_complete]
-            env[:force_timeout_complete] = true
-            raise Goliath::Validation::RequestTimeoutError.new("Request exceeded #{timeout} seconds")
-          end
-        end
       end
     end
   end

--- a/lib/goliath/contrib/rack/force_timeout.rb
+++ b/lib/goliath/contrib/rack/force_timeout.rb
@@ -1,0 +1,60 @@
+module Goliath
+  module Contrib
+    module Rack
+
+      #
+      # Force a timeout after given number of seconds
+      #
+      class ForceTimeout
+        include Goliath::Rack::Validator
+
+        # @param app [Proc] The application
+        # @return [Goliath::Rack::AsyncMiddleware]
+        def initialize(app)
+          @app     = app
+        end
+
+        # @param env [Goliath::Env] The goliath environment
+        # @return [Array] The [status_code, headers, body] tuple
+        def call(env, *args)
+          timeout = [0.0, [env[:force_timeout].to_f, 10.0].min].max
+
+          if (timeout != 0.0)
+            async_cb = env['async.callback']
+            env[:force_timeout_complete] = false
+
+            # Normal callback, executed by downstream middleware
+            # If not handled elsewhere, mark as handled and pass along unchanged
+            env['async.callback'] = Proc.new do |status, headers, body|
+              unless env[:force_timeout_complete]
+                env[:force_timeout_complete] = true
+                async_cb.call([status, headers, body])
+              end
+            end
+
+            # timeout callback, executed by EM timer.
+            # This will always fire, we just don't do anything if already handled.
+            # If not handled elsewhere, mark as handled and raise an error
+            EM.add_timer(timeout) do
+              async_cb.call(safely(env){ handle_timeout(env, timeout) })
+            end
+          end
+
+          status, headers, body = @app.call(env)
+
+          if status == Goliath::Connection::AsyncResponse.first
+            env[:force_timeout_complete] = true
+          end
+          [status, headers, body]
+        end
+
+        def handle_timeout(env, timeout)
+          unless env[:force_timeout_complete]
+            env[:force_timeout_complete] = true
+            raise Goliath::Validation::RequestTimeoutError.new("Request exceeded #{timeout} seconds")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/goliath/contrib/rack/handle_exceptions.rb
+++ b/lib/goliath/contrib/rack/handle_exceptions.rb
@@ -39,9 +39,9 @@ module Goliath
           })
         headers.delete('Content-Length')
         body    = {
-          "error"   => err.class.to_s.gsub(/.*::/,""),
-          "message" => err.message,
-          "status"  => err.status_code
+          status:  err.status_code,
+          error:   err.class.to_s.gsub(/.*::/,"/"),
+          message: err.message,
         }
         [err.status_code, headers, body]
       end

--- a/lib/goliath/contrib/rack/handle_exceptions.rb
+++ b/lib/goliath/contrib/rack/handle_exceptions.rb
@@ -1,0 +1,51 @@
+module Goliath
+  module Contrib
+    module Rack
+
+      # Rescue validation errors in the app just as you do
+      # in middleware
+      class HandleExceptions
+        include Goliath::Rack::AsyncMiddleware
+        include Goliath::Rack::Validator
+        def call(env)
+          safely(env){ super }
+        end
+      end
+
+    end
+  end
+
+  module Rack
+    module Validator
+      module_function
+
+      # @param status_code [Integer] HTTP status code for this error.
+      # @param msg [String] message to inject into the response body.
+      # @param headers [Hash] Response headers to preserve in an error response;
+      #   (the Content-Length header, if any, is removed)
+      def validation_error(status_code, msg, headers={})
+        err_class = Goliath::HTTP_ERRORS[status_code.to_i]
+        err = err_class ? err_class.new(msg) : Goliath::Validation::Error.new(status_code, msg)
+        error_response(err, headers)
+      end
+
+      # @param err [Goliath::Validation::Error] error to describe in response
+      # @param headers [Hash] Response headers to preserve in an error response;
+      #   (the Content-Length header, if any, is removed)
+      def error_response(err, headers={})
+        headers.merge!({
+            'X-Error-Message' => err.class.default_message,
+            'X-Error-Detail'  => err.message,
+          })
+        headers.delete('Content-Length')
+        body    = {
+          "error"   => err.class.to_s.gsub(/.*::/,""),
+          "message" => err.message,
+          "status"  => err.status_code
+        }
+        [err.status_code, headers, body]
+      end
+
+    end
+  end
+end

--- a/lib/goliath/contrib/rack/handle_exceptions.rb
+++ b/lib/goliath/contrib/rack/handle_exceptions.rb
@@ -4,14 +4,26 @@ module Goliath
 
       # Rescue validation errors in the app just as you do
       # in middleware
+      #
+      # Place this as early as possible in the request chain, but after the rendering.
+      #
+      # @example For JSON-encoded responses, good and bad:
+      #   class AwesomeApp < Goliath::API
+      #     use Goliath::Rack::DefaultMimeType           # cleanup accepted media types
+      #     use Goliath::Rack::Render, 'json'            # auto-negotiate response format
+      #     use Goliath::Contrib::Rack::HandleExceptions # turn raised errors into HTTP responses
+      #     use Goliath::Rack::Params                    # parse & merge query and body parameters
+      #     # ... awesomeness goes here ...
+      #   end
+      #
       class HandleExceptions
         include Goliath::Rack::AsyncMiddleware
         include Goliath::Rack::Validator
+
         def call(env)
           safely(env){ super }
         end
       end
-
     end
   end
 
@@ -40,7 +52,7 @@ module Goliath
         headers.delete('Content-Length')
         body    = {
           status:  err.status_code,
-          error:   err.class.to_s.gsub(/.*::/,"/"),
+          error:   err.class.to_s.gsub(/.*::/,""),
           message: err.message,
         }
         [err.status_code, headers, body]

--- a/lib/goliath/contrib/rack/statsd_logger.rb
+++ b/lib/goliath/contrib/rack/statsd_logger.rb
@@ -1,0 +1,42 @@
+module Goliath
+  module Contrib
+    module Rack
+
+      # Record the duration and count of all requests, report them to statsd
+      #
+      # @example a dhardbaord view on the log data
+      #   # assumes graphite dashboard on 33.33.33.30
+      #   http://33.33.33.30:5100/render/?from=-10minutes&width=960&height=720&colorList=67A9CF,91CF60,1A9850,FC8D59,D73027&bgcolor=FFFFF0&fgcolor=808080&target=stats.timers.statsd_demo.dur.root.mean_90&target=stats.timers.statsd_demo.dur.200.mean_90&target=stats.timers.statsd_demo.dur.200.upper_90&target=group(stats.timers.statsd_demo.dur.[0-9]*.mean_90)&target=group(stats.timers.statsd_demo.dur.[0-6]*.count)
+      #
+      class StatsdLogger
+        include Goliath::Rack::AsyncMiddleware
+
+        attr_reader :statsd
+
+        # @param [Goliath::Application] app
+        # @param [Goliath::Contrib::StatsdAgent] statsd Sends metrics to the statsd server
+        def initialize(app, statsd)
+          @statsd = statsd
+          super(app)
+        end
+
+        def call(env)
+          statsd.count [:req, 'route', dotted_route(env)]
+          super(env)
+        end
+
+        def post_process(env, status, headers, body)
+          ms_elapsed = (1000 * (Time.now.to_f - env[:start_time].to_f))
+          statsd.timing([:dur, 'route', dotted_route(env)], ms_elapsed)
+          statsd.timing([:dur, status],            ms_elapsed)
+          [status, headers, body]
+        end
+
+        def dotted_route(env)
+          path = env['PATH_INFO'].gsub(%r{^/}, '')
+          (path == '') ? 'root' : path.gsub(%r{/}, '.')
+        end
+      end
+    end
+  end
+end

--- a/lib/goliath/contrib/statsd_agent.rb
+++ b/lib/goliath/contrib/statsd_agent.rb
@@ -1,0 +1,84 @@
+require 'goliath/contrib/plugin/statsd_plugin'
+require 'goliath/contrib/rack/statsd_logger'
+
+module Goliath
+  module Contrib
+
+    #
+    # Send metrics to a statsd server. 
+    #
+    class StatsdAgent
+      DEFAULT_HOST = '127.0.0.1' unless defined?(DEFAULT_HOST)
+      DEFAULT_PORT = 8125        unless defined?(DEFAULT_PORT)
+      DEFAULT_FRAC = 1.0         unless defined?(DEFAULT_FRAC)
+
+      attr_reader   :prefix
+      attr_reader   :port
+      attr_reader   :host
+      attr_accessor :logger
+
+      # @param prefix [String]        prepended to all metrics this agent dispatches.
+      # @param logger [Log4R::Logger] The logger
+      # @param host   [String]        statsd hostname
+      # @param port   [Integer]       statsd port number
+      #
+      # @return [Goliath::Contrib::Plugins::StatsdAgent] the statsd sender
+      def initialize(prefix, host=nil, port=nil)
+        @prefix = prefix
+        @host   = host   || DEFAULT_HOST
+        @port   = port   || DEFAULT_PORT
+      end
+
+      # Count an event.
+      #
+      # @param [String]  metric        the name of the metric (the agent's prefix, if any, will be prepended before sending)
+      # @param [Integer] count         the number of new events to register
+      # @param [Float]   sampling_frac if you are only recording some of the events, indicate the fraction here and statsd will take care of the rest
+      #
+      # @example
+      #   FSF = 0.001
+      #   # only record one fluxion event per thousand
+      #   statsd_agent.count('hemiconducer.fluxions', 1, FSF) if (rand < FSF)
+      #
+      def count(metric, val=1, sampling_frac=nil)
+        handle = metric_handle(metric)
+        if sampling_frac && (rand < sampling_frac.to_F)
+          send_to_statsd "#{handle}:#{val}|c|@#{sampling_frac}"
+        else
+          send_to_statsd "#{handle}:#{val}|c"
+        end
+      end
+
+      # Report on the timing of an event -- a web request, perhaps.
+      #
+      # @param [String]  metric        the name` of the metric (the agent's prefix, if any, will be prepended before sending)
+      # @param [Float]   val           the duration to record, in milliseconds
+      #
+      def timing(metric, val)
+        handle = metric_handle(metric)
+        send_to_statsd "#{handle}:#{val}|ms"
+      end
+
+    protected
+
+      # @return [String] a dot-separated confection of the app-wide prefix and this metric's segments
+      def metric_handle(metric=[])
+        [@prefix, metric].flatten.reject{|x| x.to_s.empty? }.join(".")
+      end
+
+      # actually dispatch the metric
+      def send_to_statsd(metric)
+        @logger.debug{ "#{self.class} #{prefix} sending #{metric} to #{@host}:#{@port}" }
+        socket.send_datagram metric, @host, @port
+      end
+
+      # @return [EM::Connection] The actual sender
+      def socket
+        return @socket if @socket
+        @logger.info{ "#{self.class} #{prefix} opening connection to #{@host}:#{@port}" }
+        @socket = EventMachine::open_datagram_socket('', 0, EventMachine::Connection)
+      end
+
+    end
+  end
+end

--- a/lib/goliath/contrib/version.rb
+++ b/lib/goliath/contrib/version.rb
@@ -1,0 +1,5 @@
+module Goliath
+  module Contrib
+    VERSION = "1.0.0.beta1"
+  end
+end

--- a/spec/goliath/contrib/son_of_a_batch_spec.rb
+++ b/spec/goliath/contrib/son_of_a_batch_spec.rb
@@ -1,0 +1,47 @@
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+
+describe "SonOfABatch" do
+
+  describe "timeout param" do
+    it "accepts a timeout param"
+    it "coerces the timeout param within range"
+  end
+
+  describe "request format" do
+    it "requires well-formed URLs (BadRequestError)"
+    it "requires one or more URLs (BadRequestError)"
+    it "accepts at most 100 URLs at a time (BadRequestError)"
+
+    it "raises ForbiddenError if URL is not whitelisted"
+  end
+
+  describe "proxy" do
+    it "sends requests to multiple downstream hosts"
+  end
+
+  context "JSON response" do
+    it "returns a well-formed hash" do
+      # parsed_response = {}
+      # parsed_response['results'].should be_a_kind_of(Hash)
+      # parsed_response['errors'].should be_a_kind_of(Hash)
+    end
+
+    it "ends each result line except the last with a comma"
+    it "sends the stats back in a single line"
+    it "sends the errors back in a single line"
+    it "escapes the target response"
+    it "sends back the errors last" do
+    end
+
+    it "considers a successful non-200 from the client to be a result, not an error"
+  end
+
+  context 'TSV response' do
+    it "sends [event_type, request_id, status, body], tab-separated"
+    it "serializes out errors and results in order received"
+    it "removes newlines or linefeeds in the response"
+    it "does not mess with tabs in the response"
+    it "sends a stats line at the end"
+    it "considers a successful non-200 from the client to be a result, not an error"
+  end
+end

--- a/spec/goliath/contrib_spec.rb
+++ b/spec/goliath/contrib_spec.rb
@@ -1,0 +1,6 @@
+
+describe Goliath::Contrib do
+  it 'has a version' do
+    Goliath::Contrib::VERSION.should be_a(String)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,14 @@
+require 'bundler'
+
+Bundler.setup
+Bundler.require
+
+require 'goliath/test_helper'
+
+Goliath.env = :test
+
+RSpec.configure do |c|
+  c.include Goliath::TestHelper, :example_group => {
+    :file_path => /spec\/integration/
+  }
+end


### PR DESCRIPTION
son_of_a_batch -- lets one request to an endpoint become dozens of concurrent requests to remote sites. Really handy when you want to scatter-gather HTTP calls from a non-concurrent system like rails" .

Note that this branch includes the commits from all the other pending pull requests.

Also included:
- CORS (Cross-Origin site headers)
- a little script I made when figuring out how fibers and EM worked, showing the brain-bendy timeline
