### PR TITLE
Middleware to parse Rails style url parameters

### DIFF
--- a/lib/goliath/contrib.rb
+++ b/lib/goliath/contrib.rb
@@ -4,5 +4,5 @@
 
 module Goliath
   # autoload :MiddlewareName, "goliath/contrib/middleware_name"
-  # ...
+  autoload :PathParams, 'goliath/contrib/path_params'
 end

--- a/lib/goliath/contrib/path_params.rb
+++ b/lib/goliath/contrib/path_params.rb
@@ -1,0 +1,61 @@
+require 'rack/utils'
+
+module Goliath
+  module Contrib
+
+    # A middleware to parse Rails-style path parameters. This will parse
+    # parameters from the request path based on the supplied pattern and
+    # place them in the _params_ hash of the Goliath::Env for the request.
+    #
+    # @example
+    #  use Goliath::Contrib::Rack::PathParams, '/records/:artist/:title'
+    #
+    class PathParams
+
+      module Parser
+
+        PARAM = %r{:([^/]+)(\/|$)}
+        CAPTURE_GROUP = '(?<\1>[^\/\?]+)\2'
+
+        def retrieve_params(env)
+          md = matched_params(env)
+          md.names.each_with_object({}) do |key, params|
+            params[key] = md[key]
+          end
+        end
+
+        def matched_params(env)
+          request_path(env).match(regexp).tap do |matched|
+            raise Goliath::Validation::BadRequestError, "Request path does not match expected pattern: #{request_path(env)}" if matched.nil?
+          end
+        end
+
+        def request_path(env)
+          env[Goliath::Request::REQUEST_PATH]
+        end
+
+        def regexp
+          @regexp ||= %r{^#{@url_pattern.gsub(PARAM, CAPTURE_GROUP)}\/?$}
+        end
+
+      end
+
+      include Goliath::Rack::Validator
+      include Parser
+
+      def initialize(app, url_pattern)
+        @app = app
+        @url_pattern = url_pattern
+      end
+
+      def call(env)
+        Goliath::Rack::Validator.safely(env) do
+          env['params'] ||= {}
+          env['params'].merge! retrieve_params(env)
+          @app.call(env)
+        end
+      end
+
+    end
+  end
+end

--- a/spec/goliath/contrib/path_params_spec.rb
+++ b/spec/goliath/contrib/path_params_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+require 'goliath/contrib/path_params'
+
+describe Goliath::Contrib::PathParams do
+  it 'accepts an app and a url pattern' do
+    lambda { Goliath::Contrib::PathParams.new('my app', 'url') }.should_not raise_error
+  end
+
+  describe 'with middleware' do
+    before(:each) do
+      @app = mock('app').as_null_object
+      @env = { 'REQUEST_PATH' => '/records/the_fall/hex_enduction_hour' }
+      @path_params = Goliath::Contrib::PathParams.new(@app, '/records/:artist/:title')
+    end
+
+    it 'returns the app status, headers and body' do
+      app_headers = {'Content-Type' => 'app'}
+      app_body = {'b' => 'c'}
+      @app.should_receive(:call).and_return([201, app_headers, app_body])
+
+      status, headers, body = @path_params.call(@env)
+      status.should == 201
+      headers.should == app_headers
+      body.should == app_body
+    end
+
+    context 'a request that matches the url pattern' do
+      before do
+        @env = { 'REQUEST_PATH' => '/records/sparks/angst_in_my_pants' }
+      end
+
+      it 'parses the params from the path' do
+        @path_params.call(@env)
+        @env['params']['artist'].should == 'sparks'
+        @env['params']['title'].should == 'angst_in_my_pants'
+      end
+    end
+
+    context 'a request that does not match the url pattern' do
+      before do
+        @env = { 'REQUEST_PATH' => '/animals/cat/noah' }
+      end
+
+      it 'raises a BadRequestError' do
+        expect{ @path_params.retrieve_params(@env) }.to raise_error(Goliath::Validation::BadRequestError)
+      end
+    end
+
+  end
+end

--- a/spec/integration/rails_style_url_params_spec.rb
+++ b/spec/integration/rails_style_url_params_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+class RailsStyleParams < Goliath::API
+  use Goliath::Contrib::PathParams, '/kittens/:name/:favourite_colour'
+
+  def response(env)
+    [200, {}, 'OK']
+  end
+end
+
+describe RailsStyleParams do
+  let(:err) { Proc.new { fail "API request failed" } }
+
+  context 'a valid path' do
+    it 'returns OK' do
+      with_api(RailsStyleParams) do
+        get_request({:path => '/kittens/ginger/blue'}, err) do |c|
+          c.response.should == 'OK'
+        end
+      end
+    end
+  end
+
+  context 'an invalid path' do
+    it 'returns an error' do
+      with_api(RailsStyleParams) do
+        get_request({:path => '/donkeys/toothy'}, err) do |c|
+          c.response.should == '[:error, "Request path does not match expected pattern: /donkeys/toothy"]'
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/rails_style_url_params_spec.rb
+++ b/spec/integration/rails_style_url_params_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'goliath/contrib/path_params'
 
 class RailsStyleParams < Goliath::API
   use Goliath::Contrib::PathParams, '/kittens/:name/:favourite_colour'


### PR DESCRIPTION
Hi, I've created a piece of middleware to parse Rails style URL params. It accepts a URL pattern in the same format as a rails routes file and parses out the params, adding them to the `env['params']` hash.

So for example with this in your API:

```
use Goliath::Contrib::PathParams, '/kittens/:name/:favourite_colour'
```

a request path of `'/kittens/jeremy/mauve'` would lead to a params hash containing:

```
{ 'name' => 'jeremy', 'favourite_colour' => 'mauve' }
```
